### PR TITLE
Add unit tests for and fix ConcreteNodeConverter

### DIFF
--- a/ProjectGagSpeak.Tests/Hardcode/ForcedStay/TextNodeTypesTests.cs
+++ b/ProjectGagSpeak.Tests/Hardcode/ForcedStay/TextNodeTypesTests.cs
@@ -313,5 +313,41 @@ public class ConcreteNodeConverterTests
             var folderNodeNested = (TextFolderNode)folderNode.Children[0];
             Assert.IsType<TextEntryNode>(folderNodeNested.Children[0]);
         }
+        
+        [Fact]
+        void GivenAnOutdatedJsonTextFolder_WhenReadJsonIsCalled_ThenItShouldReturnATextFolderNode()
+        {
+            // Arrange
+            var json = """
+                       {
+                           "Enabled": true,
+                           "FriendlyName": "ForcedDeclineList",
+                           "TargetRestricted": false,
+                           "TargetNodeName": "",
+                           "Children": [
+                               {
+                                   "Enabled": true,
+                                   "FriendlyName": "[ForcedStay] Prevent Apartment Leaving",
+                                   "TargetRestricted": true,
+                                   "TargetNodeName": "Exit",
+                                   "TargetNodeLabel": "",
+                                   "TargetNodeLabelIsRegex": false,
+                                   "SelectedOptionText": "Cancel"
+                               }
+                           ]
+                       }
+                       """;
+            var sut = new ConcreteNodeConverter();
+            var serializer = new JsonSerializer();
+            var jsonReader = new JsonTextReader(new StringReader(json));
+
+            // Act
+            var res = sut.ReadJson(jsonReader, typeof(string), null, serializer);
+
+            // Expect
+            Assert.IsType<TextFolderNode>(res);
+            var folderNode = (TextFolderNode)res;
+            Assert.IsType<TextEntryNode>(folderNode.Children[0]);
+        }
     }
 }

--- a/ProjectGagSpeak.Tests/Hardcode/ForcedStay/TextNodeTypesTests.cs
+++ b/ProjectGagSpeak.Tests/Hardcode/ForcedStay/TextNodeTypesTests.cs
@@ -1,0 +1,317 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using GagSpeak.Hardcore.ForcedStay;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace ProjectGagSpeak.Tests.Hardcode.ForcedStay;
+
+public class TextNodeTypesTests { }
+
+public class ConcreteNodeConverterTests
+{
+    public class CanConvertTests
+    {
+        [Fact]
+        void GivenATextEntryNodeType_WhenCanConvertIsCalled_THenItShouldReturnTrue()
+        {
+            // Arrange
+            var sut = new ConcreteNodeConverter();
+
+            // Act
+            var res = sut.CanConvert(typeof(TextEntryNode));
+
+            // Assert
+            Assert.True(res);
+        }
+
+        [Fact]
+        void GivenAChambersTextNodeType_WhenCanConvertIsCalled_THenItShouldReturnTrue()
+        {
+            // Arrange
+            var sut = new ConcreteNodeConverter();
+
+            // Act
+            var res = sut.CanConvert(typeof(ChambersTextNode));
+
+            // Assert
+            Assert.True(res);
+        }
+
+        [Fact]
+        void GivenATextFolderNodeType_WhenCanConvertIsCalled_THenItShouldReturnTrue()
+        {
+            // Arrange
+            var sut = new ConcreteNodeConverter();
+
+            // Act
+            var res = sut.CanConvert(typeof(TextFolderNode));
+
+            // Assert
+            Assert.True(res);
+        }
+
+        [Fact]
+        void GivenAString_WhenCanConvertIsCalled_THenItShouldReturnFalse()
+        {
+            // Arrange
+            var sut = new ConcreteNodeConverter();
+
+            // Act
+            var res = sut.CanConvert(typeof(string));
+
+            // Assert
+            Assert.False(res);
+        }
+    }
+
+    public class WriteJsonTests
+    {
+        const string TextEntryNodeSimpleName = "GagSpeak.Hardcore.ForcedStay.TextEntryNode, ProjectGagSpeak";
+        const string ChambersTextNodeSimpleName = "GagSpeak.Hardcore.ForcedStay.ChambersTextNode, ProjectGagSpeak";
+        const string TextFolderNodeSimpleName = "GagSpeak.Hardcore.ForcedStay.TextFolderNode, ProjectGagSpeak";
+
+        [Fact]
+        void GivenATextEntryNode_WhenObjectIsSerialized_ThenItShouldIncludeATypeProperty() =>
+            TestITextNode(GivenTextEntryNode(), TextEntryNodeSimpleName);
+
+        [Fact]
+        void GivenAChambersTextNode_WhenObjectIsSerialized_ThenItShouldIncludeATypeProperty() =>
+            TestITextNode(GivenChambersTextNode(), ChambersTextNodeSimpleName);
+
+        [Fact]
+        void GivenATextFolderNode_WhenObjectIsSerialized_ThenItShouldIncludeATypeProperty() =>
+            TestITextNode(GivenTextFolderNode(), TextFolderNodeSimpleName);
+
+        [Fact]
+        void GivenATextFolderNodeWithChilderen_WhenObjectIsSerialized_ThenTheChildrenShouldHaveAType()
+        {
+            // Arrange
+            var textEntryNode = GivenTextFolderNode();
+            var sut = new ConcreteNodeConverter();
+            var serializer = new JsonSerializer();
+            var stringWriter = new StringWriter();
+            var jsonWriter = new JsonTextWriter(stringWriter);
+
+            // Act
+            sut.WriteJson(jsonWriter, textEntryNode, serializer);
+            var res = stringWriter.ToString();
+
+            // Assert
+            var jObject = JObject.Parse(res);
+
+            Assert.True(jObject.TryGetValue("Children", out JToken jType));
+            Assert.IsType<JArray>(jType);
+            var array = (JArray)jType;
+            var first = array[0];
+            var second = array[1];
+
+            Assert.IsType<JObject>(first);
+            Assert.IsType<JObject>(second);
+            var firstObject = (JObject)first;
+            var secondObject = (JObject)second;
+
+            Assert.True(firstObject.TryGetValue("$type", out JToken jFirstType));
+            Assert.True(secondObject.TryGetValue("$type", out JToken jSecondType));
+
+            Assert.Equal(jFirstType, ChambersTextNodeSimpleName);
+            Assert.Equal(jSecondType, TextEntryNodeSimpleName);
+        }
+
+        private void TestITextNode(ITextNode textNode, string expectedType)
+        {
+            // Arrange
+            var textEntryNode = textNode;
+            var sut = new ConcreteNodeConverter();
+            var serializer = new JsonSerializer();
+            var stringWriter = new StringWriter();
+            var jsonWriter = new JsonTextWriter(stringWriter);
+
+            // Act
+            sut.WriteJson(jsonWriter, textEntryNode, serializer);
+            var res = stringWriter.ToString();
+
+            // Assert
+            var jObject = JObject.Parse(res);
+
+            Assert.True(jObject.TryGetValue("$type", out JToken jType));
+            Assert.Equal(expectedType, jType.Value<string>());
+        }
+
+        private TextEntryNode GivenTextEntryNode() => new TextEntryNode()
+        {
+            Enabled = true,
+            FriendlyName = "FriendlyName",
+            TargetRestricted = true,
+            TargetNodeName = "TargetNodeName",
+            TargetNodeLabel = "TargetNodeLabel",
+            SelectedOptionText = "SelectedOptionText",
+        };
+
+        private TextFolderNode GivenTextFolderNode() => new TextFolderNode()
+        {
+            Enabled = true,
+            FriendlyName = "FriendlyName",
+            TargetRestricted = true,
+            TargetNodeName = "TargetNodeName",
+            Children =
+            {
+                GivenChambersTextNode(),
+                GivenTextEntryNode()
+            }
+        };
+
+        private ChambersTextNode GivenChambersTextNode() => new ChambersTextNode()
+        {
+            Enabled = true,
+            FriendlyName = "FriendlyName",
+            TargetRestricted = true,
+            TargetNodeName = "TargetNodeName",
+            ChamberRoomSet = 0,
+            ChamberListIdx = 0,
+        };
+    }
+
+    public class ReadJsonTests
+    {
+        [Fact]
+        void GivenJsonOfATextEntryNode_WhenReadJsonIsCalled_ThenItShouldReturnATextEntryNode()
+        {
+            // Arrange
+            var json = """
+                       {
+                           "$type": "GagSpeak.Hardcore.ForcedStay.TextEntryNode, ProjectGagSpeak",
+                           "Enabled": false,
+                           "FriendlyName": "(Friendly Name)",
+                           "TargetRestricted": true,
+                           "TargetNodeName": "",
+                           "TargetNodeLabel": "",
+                           "TargetNodeLabelIsRegex": false,
+                           "SelectedOptionText": ""
+                       }
+                       """;
+            var sut = new ConcreteNodeConverter();
+            var serializer = new JsonSerializer();
+            var jsonReader = new JsonTextReader(new StringReader(json));
+
+            // Act
+            var res = sut.ReadJson(jsonReader, typeof(string), null, serializer);
+
+            // Expect
+            Assert.IsType<TextEntryNode>(res);
+        }
+
+        [Fact]
+        void GivenJsonOfAChambersTextNode_WhenReadJsonIsCalled_ThenItShouldReturnAChambersTextNode()
+        {
+            // Arrange
+            var json = """
+                       {
+                           "$type": "GagSpeak.Hardcore.ForcedStay.ChambersTextNode, ProjectGagSpeak",
+                           "Enabled": true,
+                           "FriendlyName": "[ForcedStay] Select FC Chamber Room (2/3)",
+                           "TargetRestricted": true,
+                           "TargetNodeName": "Entrance to Additional Chambers",
+                           "ChamberRoomSet": 0,
+                           "ChamberListIdx": 0
+                       }
+                       """;
+            var sut = new ConcreteNodeConverter();
+            var serializer = new JsonSerializer();
+            var jsonReader = new JsonTextReader(new StringReader(json));
+
+            // Act
+            var res = sut.ReadJson(jsonReader, typeof(string), null, serializer);
+
+            // Expect
+            Assert.IsType<ChambersTextNode>(res);
+        }
+
+        [Fact]
+        void GivenJsonOfATextFolderNode_WhenReadJsonIsCalled_ThenItShouldReturnATextFolderNode()
+        {
+            // Arrange
+            var json = """
+                       {
+                           "$type": "GagSpeak.Hardcore.ForcedStay.TextFolderNode, ProjectGagSpeak",
+                           "Enabled": true,
+                           "FriendlyName": "ForcedDeclineList",
+                           "TargetRestricted": false,
+                           "TargetNodeName": "",
+                           "Children": [
+                               {
+                                   "$type": "GagSpeak.Hardcore.ForcedStay.TextEntryNode, ProjectGagSpeak",
+                                   "Enabled": true,
+                                   "FriendlyName": "[ForcedStay] Prevent Apartment Leaving",
+                                   "TargetRestricted": true,
+                                   "TargetNodeName": "Exit",
+                                   "TargetNodeLabel": "",
+                                   "TargetNodeLabelIsRegex": false,
+                                   "SelectedOptionText": "Cancel"
+                               }
+                           ]
+                       }
+                       """;
+            var sut = new ConcreteNodeConverter();
+            var serializer = new JsonSerializer();
+            var jsonReader = new JsonTextReader(new StringReader(json));
+
+            // Act
+            var res = sut.ReadJson(jsonReader, typeof(string), null, serializer);
+
+            // Expect
+            Assert.IsType<TextFolderNode>(res);
+            var folderNode = (TextFolderNode)res;
+            Assert.IsType<TextEntryNode>(folderNode.Children[0]);
+        }
+
+        [Fact]
+        void
+            GivenJsonOfATextFolderNodeWithNestedTextFolderNodes_WhenReadJsonIsCalled_ThenItShouldReturnATextFolderNode()
+        {
+            // Arrange
+            var json = """
+                       {
+                           "$type": "GagSpeak.Hardcore.ForcedStay.TextFolderNode, ProjectGagSpeak",
+                           "Enabled": true,
+                           "FriendlyName": "ForcedDeclineList",
+                           "TargetRestricted": false,
+                           "TargetNodeName": "",
+                           "Children": [
+                               {
+                                   "$type": "GagSpeak.Hardcore.ForcedStay.TextFolderNode, ProjectGagSpeak",
+                                   "Enabled": true,
+                                   "FriendlyName": "ForcedDeclineList",
+                                   "TargetRestricted": false,
+                                   "TargetNodeName": "",
+                                   "Children": [
+                                       {
+                                           "$type": "GagSpeak.Hardcore.ForcedStay.TextEntryNode, ProjectGagSpeak",
+                                           "Enabled": true,
+                                           "FriendlyName": "[ForcedStay] Prevent Apartment Leaving",
+                                           "TargetRestricted": true,
+                                           "TargetNodeName": "Exit",
+                                           "TargetNodeLabel": "",
+                                           "TargetNodeLabelIsRegex": false,
+                                           "SelectedOptionText": "Cancel"
+                                       }
+                                   ]
+                               }
+                           ]
+                       }
+                       """;
+            var sut = new ConcreteNodeConverter();
+            var serializer = new JsonSerializer();
+            var jsonReader = new JsonTextReader(new StringReader(json));
+
+            // Act
+            var res = sut.ReadJson(jsonReader, typeof(string), null, serializer);
+
+            // Expect
+            Assert.IsType<TextFolderNode>(res);
+            var folderNode = (TextFolderNode)res;
+            Assert.IsType<TextFolderNode>(folderNode.Children[0]);
+            var folderNodeNested = (TextFolderNode)folderNode.Children[0];
+            Assert.IsType<TextEntryNode>(folderNodeNested.Children[0]);
+        }
+    }
+}

--- a/ProjectGagSpeak.Tests/ProjectGagSpeak.Tests.csproj
+++ b/ProjectGagSpeak.Tests/ProjectGagSpeak.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0-windows</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="coverlet.collector" Version="6.0.0"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
+        <PackageReference Include="xunit" Version="2.5.3"/>
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="Xunit"/>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\ProjectGagSpeak\ProjectGagSpeak.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/ProjectGagSpeak.sln
+++ b/ProjectGagSpeak.sln
@@ -17,6 +17,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Penumbra.String", "Penumbra
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ProjectGagSpeak", "ProjectGagSpeak\ProjectGagSpeak.csproj", "{074EF6F6-70FE-4813-9881-5D28FC6F757A}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{F01F4DB8-65D5-4A58-8279-685C01B04813}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProjectGagSpeak.Tests", "ProjectGagSpeak.Tests\ProjectGagSpeak.Tests.csproj", "{C81B3229-028D-4E2B-BF01-3A38CEA93EDD}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -51,11 +55,18 @@ Global
 		{074EF6F6-70FE-4813-9881-5D28FC6F757A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{074EF6F6-70FE-4813-9881-5D28FC6F757A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{074EF6F6-70FE-4813-9881-5D28FC6F757A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C81B3229-028D-4E2B-BF01-3A38CEA93EDD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C81B3229-028D-4E2B-BF01-3A38CEA93EDD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C81B3229-028D-4E2B-BF01-3A38CEA93EDD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C81B3229-028D-4E2B-BF01-3A38CEA93EDD}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {E10136AA-C46B-4F70-A4B5-044DC759D0F4}
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{C81B3229-028D-4E2B-BF01-3A38CEA93EDD} = {F01F4DB8-65D5-4A58-8279-685C01B04813}
 	EndGlobalSection
 EndGlobal

--- a/ProjectGagSpeak/GagspeakConfiguration/Configurations/GagspeakConfig.cs
+++ b/ProjectGagSpeak/GagspeakConfiguration/Configurations/GagspeakConfig.cs
@@ -4,6 +4,7 @@ using GagSpeak.Hardcore;
 using GagSpeak.Hardcore.ForcedStay;
 using GagSpeak.Hardcore.Movement;
 using GagSpeak.UI;
+using Newtonsoft.Json.Converters;
 
 namespace GagSpeak.GagspeakConfiguration.Configurations;
 
@@ -73,6 +74,7 @@ public class GagspeakConfig : IGagspeakConfiguration
     public BlindfoldType BlindfoldStyle { get; set; } = BlindfoldType.Sensual; // Blindfold Format
     public bool ForceLockFirstPerson { get; set; } = false; // Force First-Person state while blindfolded.
     public float BlindfoldOpacity { get; set; } = 1.0f; // Blindfold Opacity
+    [JsonConverter(typeof(ConcreteNodeConverter))]
     public TextFolderNode ForcedStayPromptList { get; private set; } = new TextFolderNode { FriendlyName = "ForcedDeclineList" }; // ForcedToStay storage
     public bool MoveToChambersInEstates { get; set; } = false; // Move to Chambers in Estates during ForcedStay
 }

--- a/ProjectGagSpeak/Hardcore/ForcedStay/TextNodeTypes.cs
+++ b/ProjectGagSpeak/Hardcore/ForcedStay/TextNodeTypes.cs
@@ -300,11 +300,11 @@ public class ConcreteNodeConverter : JsonConverter
         {
             return CreateObject<TextEntryNode>(jObject, serializer);
         }
-        else if (jType == SimpleName(typeof(ChambersTextNode)))
+        if (jType == SimpleName(typeof(ChambersTextNode)))
         {
             return CreateObject<ChambersTextNode>(jObject, serializer);
         }
-        else if (jType == SimpleName(typeof(TextFolderNode)))
+        if (jType == SimpleName(typeof(TextFolderNode)))
         {
             return CreateObject<TextFolderNode>(jObject, serializer);
         }
@@ -313,10 +313,8 @@ public class ConcreteNodeConverter : JsonConverter
         {
             return CreateObject<TextFolderNode>(jObject, serializer);
         }
-        else
-        {
-            return CreateObject<TextEntryNode>(jObject, serializer);
-        }
+        
+        return CreateObject<TextEntryNode>(jObject, serializer);
     }
 
     public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)

--- a/ProjectGagSpeak/Hardcore/ForcedStay/TextNodeTypes.cs
+++ b/ProjectGagSpeak/Hardcore/ForcedStay/TextNodeTypes.cs
@@ -127,6 +127,7 @@ public class ChambersTextNode : ITextNode
     public int ChamberListIdx { get; set; } = 0;
 }
 
+[Serializable]
 public class TextFolderNode : ITextNode
 {
     public bool Enabled { get; set; } = true;
@@ -287,12 +288,13 @@ public class ConcreteNodeConverter : JsonConverter
 
     public override bool CanWrite => true;
 
-    public override bool CanConvert(Type objectType) => objectType == typeof(ITextNode);
+    public override bool CanConvert(Type objectType) => objectType.IsAssignableTo(typeof(ITextNode));
 
     public override object ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
     {
         var jObject = JObject.Load(reader);
-        var jType = jObject["$type"]!.Value<string>();
+        // Needs to be optional for backwards compatibility
+        var jType = jObject["$type"]?.Value<string>();
 
         if (jType == SimpleName(typeof(TextEntryNode)))
         {
@@ -302,7 +304,6 @@ public class ConcreteNodeConverter : JsonConverter
         {
             return CreateObject<ChambersTextNode>(jObject, serializer);
         }
-
         else if (jType == SimpleName(typeof(TextFolderNode)))
         {
             return CreateObject<TextFolderNode>(jObject, serializer);


### PR DESCRIPTION
This fixes the following issues:
- `CanConvert` on `ConcreteNodeConverter` now correctly returns `true` for `TextFolderNode`, `TextEntryNode`, and `ChambersTextNode`
- `ReadJson` on `ConcreteNodeConverter` now has backward compatibility for `$type` not being present, as was the case before this change.
- `GagspeakConfig` now uses the correct `JsonConverter` for `TextFolderNode` (`ConcreteNodeConverter`)

meaning all currently existing `ITextNode`s are correctly serialized, and contain the `$type` in the actual config file.
<details>
  <summary>Example json</summary>

```json
{
  "": "...",
  "ForcedStayPromptList": {
    "$type": "GagSpeak.Hardcore.ForcedStay.TextFolderNode, ProjectGagSpeak",
    "Enabled": true,
    "FriendlyName": "ForcedDeclineList",
    "TargetRestricted": false,
    "TargetNodeName": "",
    "Children": [
      {
        "$type": "GagSpeak.Hardcore.ForcedStay.TextEntryNode, ProjectGagSpeak",
        "Enabled": true,
        "FriendlyName": "[ForcedStay] Prevent Apartment Leaving",
        "TargetRestricted": true,
        "TargetNodeName": "Exit",
        "TargetNodeLabel": "",
        "TargetNodeLabelIsRegex": false,
        "SelectedOptionText": "Cancel"
      },
      {
        "$type": "GagSpeak.Hardcore.ForcedStay.TextEntryNode, ProjectGagSpeak",
        "Enabled": true,
        "FriendlyName": "[ForcedStay] Prevent Chamber Leaving",
        "TargetRestricted": true,
        "TargetNodeName": "Exit",
        "TargetNodeLabel": "What would you like to do?",
        "TargetNodeLabelIsRegex": false,
        "SelectedOptionText": "Nothing."
      },
      {
        "$type": "GagSpeak.Hardcore.ForcedStay.TextEntryNode, ProjectGagSpeak",
        "Enabled": true,
        "FriendlyName": "[ForcedStay] Prevent Estate Leaving",
        "TargetRestricted": true,
        "TargetNodeName": "Exit",
        "TargetNodeLabel": "Leave the estate hall?",
        "TargetNodeLabelIsRegex": false,
        "SelectedOptionText": "No"
      },
      {
        "$type": "GagSpeak.Hardcore.ForcedStay.TextEntryNode, ProjectGagSpeak",
        "Enabled": true,
        "FriendlyName": "[ForcedStay] Auto-Enter Estate (Prevents Logout Escape)",
        "TargetRestricted": true,
        "TargetNodeName": "Entrance",
        "TargetNodeLabel": "Enter the estate hall?",
        "TargetNodeLabelIsRegex": false,
        "SelectedOptionText": "Yes"
      },
      {
        "$type": "GagSpeak.Hardcore.ForcedStay.TextEntryNode, ProjectGagSpeak",
        "Enabled": true,
        "FriendlyName": "[ForcedStay] Open Apartment Menu (1/3)",
        "TargetRestricted": true,
        "TargetNodeName": "Apartment Building Entrance",
        "TargetNodeLabel": "",
        "TargetNodeLabelIsRegex": false,
        "SelectedOptionText": "Go to specified apartment"
      },
      {
        "$type": "GagSpeak.Hardcore.ForcedStay.ChambersTextNode, ProjectGagSpeak",
        "Enabled": true,
        "FriendlyName": "[ForcedStay] Select Apartment Room (2/3)",
        "TargetRestricted": true,
        "TargetNodeName": "Apartment Building Entrance",
        "ChamberRoomSet": 0,
        "ChamberListIdx": 0
      },
      {
        "$type": "GagSpeak.Hardcore.ForcedStay.TextEntryNode, ProjectGagSpeak",
        "Enabled": true,
        "FriendlyName": "[ForcedStay] Enter Selected Apartment (3/3)",
        "TargetRestricted": true,
        "TargetNodeName": "Apartment Building Entrance",
        "TargetNodeLabel": "/^Enter .+?'s room\\\\?$/",
        "TargetNodeLabelIsRegex": true,
        "SelectedOptionText": "Yes"
      },
      {
        "$type": "GagSpeak.Hardcore.ForcedStay.TextEntryNode, ProjectGagSpeak",
        "Enabled": true,
        "FriendlyName": "[ForcedStay] Open FC Chambers Menu (1/3)",
        "TargetRestricted": true,
        "TargetNodeName": "Entrance to Additional Chambers",
        "TargetNodeLabel": "",
        "TargetNodeLabelIsRegex": false,
        "SelectedOptionText": "Move to specified private chambers"
      },
      {
        "$type": "GagSpeak.Hardcore.ForcedStay.ChambersTextNode, ProjectGagSpeak",
        "Enabled": true,
        "FriendlyName": "[ForcedStay] Select FC Chamber Room (2/3)",
        "TargetRestricted": true,
        "TargetNodeName": "Entrance to Additional Chambers",
        "ChamberRoomSet": 0,
        "ChamberListIdx": 0
      },
      {
        "$type": "GagSpeak.Hardcore.ForcedStay.TextEntryNode, ProjectGagSpeak",
        "Enabled": true,
        "FriendlyName": "[ForcedStay] Enter Selected Chamber (3/3)",
        "TargetRestricted": true,
        "TargetNodeName": "Apartment Building Entrance",
        "TargetNodeLabel": "/^Enter .+?'s room\\\\?$/",
        "TargetNodeLabelIsRegex": true,
        "SelectedOptionText": "Yes"
      }
    ]
  },
  "": "..."
}
```

</details>


This PR also adds unit testing to the project using xUnit (which I used to diagnose the issue to begin with).