### PR TITLE
Puppeteer Alias Permissions Logic Implemented

### DIFF
--- a/ProjectGagSpeak/Localization/Strings.cs
+++ b/ProjectGagSpeak/Localization/Strings.cs
@@ -702,7 +702,10 @@ namespace GagSpeak.Localization
         public readonly string GlobalAllowMotionTT = Loc.Localize("MainOptions_GlobalAllowKneelTT", "Allow anyone to request a motion action from you." +
             "--SEP--A motion request includes any emotes or expressions that can be found in Emotes." +
             "--SEP--This permission limits commands to emotes and expressions.");
-
+        public readonly string GlobalAllowAlias = Loc.Localize("MainOptions_GlobalAllowAlias", "Globally Allow Alias Requests");
+        public readonly string GlobalAllowAliasTT = Loc.Localize("MainOptions_GlobalAllowAliasTT", "Allows anyone to request that you use a global alias action you have configured." +
+            "--SEP--This permission includes any game and plugin commands that originate from an alias you have configured." +
+            "--SEP--WARNING: Use this responsibly and with caution as it will allow ANYONE to execute commands you have in your alias's.");
         public readonly string GlobalAllowAll = Loc.Localize("MainOptions_GlobalAllowAll", "Globally Allow All Requests");
         public readonly string GlobalAllowAllTT = Loc.Localize("MainOptions_GlobalAllowAllTT", "Allows anyone to request any action from you." +
             "--SEP--This permission includes any game and plugin commands, emotes and expressions." +

--- a/ProjectGagSpeak/PlayerData/Handler/PuppeteerHandler.cs
+++ b/ProjectGagSpeak/PlayerData/Handler/PuppeteerHandler.cs
@@ -161,7 +161,7 @@ public class PuppeteerHandler : DisposableMediatorSubscriberBase
     /// Parses and executes from a global trigger phrase.
     /// </summary>
     /// <returns>True if it was fired, false if not.</returns>
-    public bool ParseOutputFromGlobalAndExecute(string trigger, SeString chatMessage, XivChatType type, bool sits, bool motions, bool all)
+    public bool ParseOutputFromGlobalAndExecute(string trigger, SeString chatMessage, XivChatType type, bool sits, bool motions, bool alias, bool all)
     {
         Logger.LogTrace("Checking for trigger: " + trigger, LoggerType.Puppeteer);
         Logger.LogTrace("Message we are checking for the trigger in: " + chatMessage, LoggerType.Puppeteer);
@@ -173,11 +173,13 @@ public class PuppeteerHandler : DisposableMediatorSubscriberBase
         remainingMessage = remainingMessage.GetSubstringWithinParentheses();
         Logger.LogTrace("Remaining message after brackets: " + remainingMessage);
 
-        // if any are found here, it will perform a call to the action executer, so we can return.
-        Logger.LogTrace("Checking for Aliases");
-        var wasAnAlias = ConvertAliasCommandsIfAny(remainingMessage, _clientConfigs.AliasConfig.GlobalAliasList, MainHub.UID);
-        if (wasAnAlias)
-            return true;
+        if (alias) {
+            // Alias's will dispatch multiple commands anyways, so we can return early
+            Logger.LogTrace("Alias Permissions found, checking for Aliases");
+            var wasAnAlias = ConvertAliasCommandsIfAny(remainingMessage, _clientConfigs.AliasConfig.GlobalAliasList, MainHub.UID);
+            if (wasAnAlias)
+                return true;
+        }
 
         // otherwise, proceed to parse normal message.
         if (remainingMessage.TextValue.IsNullOrEmpty())
@@ -188,6 +190,13 @@ public class PuppeteerHandler : DisposableMediatorSubscriberBase
 
         // apply bracket conversions.
         remainingMessage = remainingMessage.ConvertSquareToAngleBrackets();
+        if (alias) {
+            // Alias's will dispatch multiple commands anyways, so we can return early
+            Logger.LogTrace("Alias Permissions found, checking for Aliases");
+            var wasAnAlias = ConvertAliasCommandsIfAny(remainingMessage, _clientConfigs.AliasConfig.GlobalAliasList, MainHub.UID);
+            if (wasAnAlias)
+                return true;
+        }
         // only apply it if the message meets the criteria for the sender.
         if (MeetsSettingCriteria(sits, motions, all, remainingMessage))
         {
@@ -213,11 +222,13 @@ public class PuppeteerHandler : DisposableMediatorSubscriberBase
         remainingMessage = remainingMessage.GetSubstringWithinParentheses(startChar, endChar);
         Logger.LogTrace("Remaining message after brackets: " + remainingMessage);
 
-        // if any are found here, it will perform a call to the action executer, so we can return.
-        Logger.LogTrace("Checking for Aliases");
-        var wasAnAlias = ConvertAliasCommandsIfAny(remainingMessage, _clientConfigs.AliasConfig.AliasStorage[SenderUid].AliasList, SenderUid);
-        if (wasAnAlias)
-            return true;
+        if (aliases) {
+            // if any are found here, it will perform a call to the action executer, so we can return.
+            Logger.LogTrace("Alias Permissions found, checking for Aliases");
+            var wasAnAlias = ConvertAliasCommandsIfAny(remainingMessage, _clientConfigs.AliasConfig.AliasStorage[SenderUid].AliasList, SenderUid);
+            if (wasAnAlias)
+                return true;
+        }
 
         // otherwise, proceed to parse normal message.
         if (remainingMessage.TextValue.IsNullOrEmpty())
@@ -228,6 +239,14 @@ public class PuppeteerHandler : DisposableMediatorSubscriberBase
 
         // apply bracket conversions.
         remainingMessage = remainingMessage.ConvertSquareToAngleBrackets();
+
+        if (aliases) {
+            Logger.LogTrace("Alias Permissions found, checking for Aliases");
+            var wasAnAlias = ConvertAliasCommandsIfAny(remainingMessage, _clientConfigs.AliasConfig.AliasStorage[SenderUid].AliasList, SenderUid);
+            if (wasAnAlias)
+                return true;
+        }
+
         // verify permissions are satisfied.
         if (MeetsSettingCriteria(sits, motions, all, remainingMessage))
         {

--- a/ProjectGagSpeak/StateManagers/Executions/ActionExecuter.cs
+++ b/ProjectGagSpeak/StateManagers/Executions/ActionExecuter.cs
@@ -88,15 +88,13 @@ public sealed class ActionExecutor
         remainingMessage = remainingMessage.ConvertSquareToAngleBrackets();
         // verify permissions are satisfied.
         var executerUID = performerUID;
-        var sits = false;
-        var motions = false;
-        var all = false;
+        
+        var aliasAllowed = false;
         // if performer is self, use global perms, otherwise, use pair perms.
         if (performerUID == MainHub.UID)
         {
-            sits = _playerData.GlobalPerms?.GlobalAllowSitRequests ?? false;
-            motions = _playerData.GlobalPerms?.GlobalAllowMotionRequests ?? false;
-            all = _playerData.GlobalPerms?.GlobalAllowAllRequests ?? false;
+            // This method is _only called_ from an alias
+            aliasAllowed = _playerData.GlobalPerms?.GlobalAllowAliasRequests ?? false;
         }
         else
         {
@@ -108,13 +106,12 @@ public sealed class ActionExecutor
             }
 
             matchedPair.OwnPerms.PuppetPerms(out bool sits2, out bool motions2, out bool alias2, out bool all2, out char startChar, out char endChar);
-            sits = sits2;
-            motions = motions2;
-            all = all2;
+            aliasAllowed = alias2;
         }
 
-        // only apply it if the message meets the criteria for the sender.
-        if (MeetsSettingCriteria(sits, motions, all, remainingMessage))
+        // Only apply this if it either originated from a trigger (or alias) 
+        // Or it it meets the various criteria for the sender.
+        if (aliasAllowed)
         {
             UnlocksEventManager.AchievementEvent(UnlocksEvent.PuppeteerOrderRecieved);
             ChatBoxMessage.EnqueueMessage("/" + remainingMessage.TextValue);

--- a/ProjectGagSpeak/UI/UiPuppeteer/PuppeteerUI.cs
+++ b/ProjectGagSpeak/UI/UiPuppeteer/PuppeteerUI.cs
@@ -300,18 +300,22 @@ public class PuppeteerUI : WindowMediatorSubscriberBase
             _components.DrawListenerClientGroup(isEditingTriggerOptions,
                 (newSits) =>
                 {
-                    _logger.LogTrace($"Updated AlowSits permission: " + newSits);
-                    _ = _apiHubMain.UserUpdateOwnPairPerm(new(_handler.SelectedPair.UserData, MainHub.PlayerUserData, new KeyValuePair<string, object>("AllowSitRequests", newSits), UpdateDir.Own));
+                    _logger.LogTrace($"Updated AllowSits permission: " + newSits);
+                    _ = _apiHubMain.UserUpdateOwnPairPerm(new(_handler.SelectedPair.UserData, MainHub.PlayerUserData, new KeyValuePair<string, object>("SitRequests", newSits), UpdateDir.Own));
                 },
                 (newMotions) =>
                 {
-                    _logger.LogTrace($"Updated AlowMotions permission: " + newMotions);
-                    _ = _apiHubMain.UserUpdateOwnPairPerm(new(_handler.SelectedPair.UserData, MainHub.PlayerUserData, new KeyValuePair<string, object>("AllowMotionRequests", newMotions), UpdateDir.Own));
+                    _logger.LogTrace($"Updated AllowMotions permission: " + newMotions);
+                    _ = _apiHubMain.UserUpdateOwnPairPerm(new(_handler.SelectedPair.UserData, MainHub.PlayerUserData, new KeyValuePair<string, object>("MotionRequests", newMotions), UpdateDir.Own));
+                },
+                (newAlias) => {
+                    _logger.LogTrace($"Updated AllowAlias permission: " + newAlias);
+                    _ = _apiHubMain.UserUpdateOwnPairPerm(new(_handler.SelectedPair.UserData, MainHub.PlayerUserData, new KeyValuePair<string, object>("AliasRequests", newAlias), UpdateDir.Own));                
                 },
                 (newAll) =>
                 {
-                    _logger.LogTrace($"Updated AlowAll permission: " + newAll);
-                    _ = _apiHubMain.UserUpdateOwnPairPerm(new(_handler.SelectedPair.UserData, MainHub.PlayerUserData, new KeyValuePair<string, object>("AllowAllRequests", newAll), UpdateDir.Own));
+                    _logger.LogTrace($"Updated AllowAll permission: " + newAll);
+                    _ = _apiHubMain.UserUpdateOwnPairPerm(new(_handler.SelectedPair.UserData, MainHub.PlayerUserData, new KeyValuePair<string, object>("AllRequests", newAll), UpdateDir.Own));
                 },
                 (newEditState) =>
                 {

--- a/ProjectGagSpeak/UI/UiSettings/SettingsUi.cs
+++ b/ProjectGagSpeak/UI/UiSettings/SettingsUi.cs
@@ -239,6 +239,7 @@ public class SettingsUi : WindowMediatorSubscriberBase
         string globalTriggerPhrase = _playerCharacterManager.GlobalPerms.GlobalTriggerPhrase;
         bool globalAllowSitRequests = _playerCharacterManager.GlobalPerms.GlobalAllowSitRequests;
         bool globalAllowMotionRequests = _playerCharacterManager.GlobalPerms.GlobalAllowMotionRequests;
+        bool globalAllowAliasRequests = _playerCharacterManager.GlobalPerms.GlobalAllowAliasRequests;
         bool globalAllowAllRequests = _playerCharacterManager.GlobalPerms.GlobalAllowAllRequests;
 
         bool moodlesEnabled = _playerCharacterManager.GlobalPerms.MoodlesEnabled;
@@ -415,7 +416,14 @@ public class SettingsUi : WindowMediatorSubscriberBase
 
             }
             _uiShared.DrawHelpText(GSLoc.Settings.MainOptions.GlobalAllowMotionTT);
+            if (ImGui.Checkbox(GSLoc.Settings.MainOptions.GlobalAllowAlias, ref globalAllowAliasRequests))
+            {
+                _playerCharacterManager.GlobalPerms.GlobalAllowAliasRequests = globalAllowAliasRequests;
+                // if this creates a race condition down the line remove the above line.
+                _ = _apiHubMain.UserUpdateOwnGlobalPerm(new(MainHub.PlayerUserData, MainHub.PlayerUserData, new KeyValuePair<string, object>("GlobalAllowAliasRequests", globalAllowAliasRequests), UpdateDir.Own));
 
+            }
+            _uiShared.DrawHelpText(GSLoc.Settings.MainOptions.GlobalAllowAliasTT);
             if (ImGui.Checkbox(GSLoc.Settings.MainOptions.GlobalAllowAll, ref globalAllowAllRequests))
             {
                 _playerCharacterManager.GlobalPerms.GlobalAllowAllRequests = globalAllowAllRequests;

--- a/ProjectGagSpeak/UpdateMonitoring/Chat/ChatboxMessage.cs
+++ b/ProjectGagSpeak/UpdateMonitoring/Chat/ChatboxMessage.cs
@@ -170,8 +170,8 @@ public class ChatBoxMessage : DisposableMediatorSubscriberBase
         if (_puppeteerHandler.IsValidTriggerWord(globalTriggers, message, out string matchedTrigger))
         {
             // check permissions.
-            _playerInfo.GlobalPerms!.PuppetPerms(out bool sit, out bool emote, out bool all);
-            if (_puppeteerHandler.ParseOutputFromGlobalAndExecute(matchedTrigger, message, type, sit, emote, all))
+            _playerInfo.GlobalPerms!.PuppetPerms(out bool sit, out bool emote, out bool alias, out bool all);
+            if (_puppeteerHandler.ParseOutputFromGlobalAndExecute(matchedTrigger, message, type, sit, emote, alias, all))
                 return; // early return to prevent double trigger call.
         }
 


### PR DESCRIPTION
- Includes the support of alias request permissions for global permissions and pair puppeteer actions. 
- Implemented support for global puppeteer alias permissions and possibly pair puppeteers.
- Removes some superfluous validation logic for the HandleTextAction used by Alias's and triggers to dispatch the requests.
- Adds the configuration options and localization placeholders for the global options.
- Fixes a regression in the Puppeteer Trigger UI that previously prevented access to setting trigger and the setting the permissions from the puppeteer UI.

*Client side only*
Tested against live GS Web Service.