### PR TITLE
Fixes Owner and Devotional Timer padlocks.

### DIFF
--- a/ProjectGagSpeak/PlayerData/Data/ClientDataChanges.cs
+++ b/ProjectGagSpeak/PlayerData/Data/ClientDataChanges.cs
@@ -138,10 +138,7 @@ public class ClientDataChanges : DisposableMediatorSubscriberBase
             {
                 Logger.LogTrace("Sending off Lock Removed Event to server!", LoggerType.PadlockHandling);
                 {
-                    if(gagSlot.Padlock.ToPadlock() is Padlocks.TimerPadlock)
-                        _appearance.GagUnlocked((GagLayer)i, gagSlot.Password, "Client", true, false);
-                    else
-                        _appearance.GagUnlocked((GagLayer)i, gagSlot.Password, gagSlot.Assigner, true, false);
+                    _appearance.GagUnlocked((GagLayer)i, gagSlot.Password, "Timer", true, false);
 
                 }
             }

--- a/ProjectGagSpeak/PlayerData/Handler/WardrobeHandler.cs
+++ b/ProjectGagSpeak/PlayerData/Handler/WardrobeHandler.cs
@@ -97,10 +97,7 @@ public class WardrobeHandler : DisposableMediatorSubscriberBase
             if (activeSet.Padlock.ToPadlock().IsTimerLock() && activeSet.Timer - DateTimeOffset.UtcNow <= TimeSpan.Zero)
             {
                 Logger.LogInformation("Active Set [" + activeSet.Name + "] has expired its lock, unlocking and removing restraint set.", LoggerType.Restraints);
-                if (activeSet.Padlock.ToPadlock() is Padlocks.TimerPadlock)
-                    _appearanceHandler.UnlockRestraintSet(activeSet.RestraintId, activeSet.Password, "Client", true, false);
-                else
-                    _appearanceHandler.UnlockRestraintSet(activeSet.RestraintId, activeSet.Password, activeSet.Assigner, true, false);
+                _appearanceHandler.UnlockRestraintSet(activeSet.RestraintId, activeSet.Password, "Timer", true, false);
             }
         }
     }

--- a/ProjectGagSpeak/StateManagers/AppearanceManager.cs
+++ b/ProjectGagSpeak/StateManagers/AppearanceManager.cs
@@ -583,7 +583,7 @@ public sealed class AppearanceManager : DisposableMediatorSubscriberBase
     private bool UpdateStateForUnlocking<T>(T item, string pass, string enactor, bool isForced) where T : IPadlockable
     {
         // if it is not forced, require the validation process.
-        if (isForced is false)
+        if (isForced is false && enactor != "Timer")
         {
             var validationResult = GsPadlockEx.ValidateUnlockUpdate(item, MainHub.PlayerUserData, pass, enactor);
             if (validationResult is not PadlockReturnCode.Success)


### PR DESCRIPTION
This is done by setting enactorUid to "Timer" for all timer locks and checking against that to force the unlock.

Verified on both restraint sets and gags.