### PR TITLE
Migrated penumbra IPC to use the new Temporary Mod feature

### DIFF
--- a/ProjectGagSpeak/PlayerData/Services/ClientPlayerConnectedService.cs
+++ b/ProjectGagSpeak/PlayerData/Services/ClientPlayerConnectedService.cs
@@ -78,6 +78,9 @@ public sealed class OnConnectedService : DisposableMediatorSubscriberBase, IHost
         // Obtain Server-Side Active State Data.
         var serverData = MainHub.ConnectionDto.ActiveRestraintData;
         var serverExpectsActiveSet = serverData.ActiveSetId != Guid.Empty;
+        // Upon connection all mods should be resynchronized with the acctive restraints/gags.
+        // This is primarily to ensure that the mods can be accurately synchronized between multiple characters.
+        _ipcManager.Penumbra.ClearAllTemporaryMods();
         // Handle it accordingly.
         if (serverExpectsActiveSet)
         {
@@ -136,6 +139,10 @@ public sealed class OnConnectedService : DisposableMediatorSubscriberBase, IHost
             await EnableAndRelockSet(serverData);
             // publish a full data wardrobe update after this.
             Mediator.Publish(new PlayerCharWardrobeChanged(WardrobeUpdateType.FullDataUpdate, string.Empty));
+        }
+        // In every other case, we have an active set that matches the server set, so we want to be sure to re-enable the temporary mods.
+        else {
+            await _appearanceHandler.PenumbraModsToggle(NewState.Enabled, activeClientSet.AssociatedMods);
         }
     }
 

--- a/ProjectGagSpeak/StateManagers/AppearanceManager.cs
+++ b/ProjectGagSpeak/StateManagers/AppearanceManager.cs
@@ -199,7 +199,7 @@ public sealed class AppearanceManager : DisposableMediatorSubscriberBase
             // Handle if we should perform glamour applications for these.(for now forced is included for safewords to work, and will be removed later during glamourer rework)
             if (_playerData.GlobalPerms.RestraintSetAutoEquip || forced)
             {
-                // Set associated mods.
+                // Set associated mods in penumbra.
                 await PenumbraModsToggle(NewState.Enabled, setRef.AssociatedMods);
                 // recalculate appearance and refresh.
                 await RecalcAndReload(false);
@@ -670,7 +670,7 @@ public sealed class AppearanceManager : DisposableMediatorSubscriberBase
     }
 
     /// <summary> Applies associated mods to the client when a Restraint or Cursed Item is toggled. </summary>
-    private Task PenumbraModsToggle(NewState state, List<AssociatedMod> associatedMods)
+    public Task PenumbraModsToggle(NewState state, List<AssociatedMod> associatedMods)
     {
         try
         {
@@ -690,9 +690,7 @@ public sealed class AppearanceManager : DisposableMediatorSubscriberBase
             {
                 // For each of the associated mods, if we marked it to disable when inactive, disable it.
                 foreach (var associatedMod in associatedMods)
-                    _ipcManager.Penumbra.ModifyModState(associatedMod,
-                        modState: NewState.Disabled,
-                        adjustPriorityOnly: associatedMod.DisableWhenInactive ? false : true);
+                    _ipcManager.Penumbra.ModifyModState(associatedMod, modState: NewState.Disabled);
 
                 // if any of those mods wanted us to perform a redraw, then do so now. (PlayerObjectIndex is always 0)
                 if (associatedMods.Any(x => x.RedrawAfterToggle))


### PR DESCRIPTION
Switching away from manually checking and toggling the mod states. Removed old unneeded methods.
Added ClearAllTemporaryMods() function to help facilitate resynchronizing penumbra. Mods toggled by GagSpeak will be noted as such in penumbra (and set to locked) On Connected, the client will automatically resync the mods with the current wardrobe settings.

Requires bumping the tracked submodule commit for Penumbra.Api to the latest on their branch.