### PR TITLE
Mods for cursed loot will now properly apply.

### DIFF
--- a/ProjectGagSpeak/PlayerData/Services/ClientPlayerConnectedService.cs
+++ b/ProjectGagSpeak/PlayerData/Services/ClientPlayerConnectedService.cs
@@ -81,6 +81,10 @@ public sealed class OnConnectedService : DisposableMediatorSubscriberBase, IHost
         // Upon connection all mods should be resynchronized with the acctive restraints/gags.
         // This is primarily to ensure that the mods can be accurately synchronized between multiple characters.
         _ipcManager.Penumbra.ClearAllTemporaryMods();
+
+        // Call AppearanceManager to reanable mods for cursed loot
+        await _appearanceHandler.CheckCursedLootForMods();
+
         // Handle it accordingly.
         if (serverExpectsActiveSet)
         {


### PR DESCRIPTION
This is a sort of bug fix to Nia's PR that properly enables mods for cursed loot after logging out and back in.

A few side notes:
- After reconnect, it will enable cursed loot mods
- After it will also enable cursed loot after handling mods for restraint sets, just in case the restraint set over wrote settings for cursed loot mods