### PR TITLE
UI fixes

### DIFF
--- a/ProjectGagSpeak/CkCommons/CkGui/CkGui.Text.cs
+++ b/ProjectGagSpeak/CkCommons/CkGui/CkGui.Text.cs
@@ -365,7 +365,8 @@ public partial class CkGui
         // Get the itemrect
         var itemRect = ImGui.GetItemRectSize();
         // run a sameline from the position to set the cursorPosX to the end for us to draw the right aligned icon.
-        ImGui.SameLine(ImGui.GetCursorPosX() + itemRect.X - ImGui.GetTextLineHeight());
+        //ImGui.SameLine(ImGui.GetCursorPosX() + itemRect.X - ImGui.GetTextLineHeight());
+        ImUtf8.SameLineInner();
         IconText(icon, ImGui.GetColorU32(ImGuiCol.Text));
     }
 }

--- a/ProjectGagSpeak/CustomCombos/Core/CkPadlockComboBase.cs
+++ b/ProjectGagSpeak/CustomCombos/Core/CkPadlockComboBase.cs
@@ -152,7 +152,7 @@ public abstract class CkPadlockComboBase<T> where T : IPadlockableRestriction
         var buttonWidth = buttonTxt.IsNullOrEmpty()
             ? CkGui.IconButtonSize(FAI.Unlock).X
             : CkGui.IconTextButtonSize(FAI.Unlock, "Unlock");
-        var unlockFieldWidth = width - buttonWidth - ImGui.GetStyle().ItemInnerSpacing.X;
+        var unlockFieldWidth = width - buttonWidth - (ImGui.GetStyle().ItemInnerSpacing.X * 6);
 
         // If for whatever reason the current layer is different from the previous, reset & regenerate inputs & combo list.
         if (_currentLayer != layerIdx)
@@ -204,7 +204,7 @@ public abstract class CkPadlockComboBase<T> where T : IPadlockableRestriction
     protected void TwoRowLockFields(string id, float width)
     {
         var leftWidth = width * (2 / 3f);
-        var rightWidth = width - leftWidth - ImGui.GetStyle().ItemInnerSpacing.X;
+        var rightWidth = leftWidth / 2f;
 
         var passFieldLabel = "##Input_" + id;
         var passFieldHint = SelectedLock switch
@@ -220,7 +220,6 @@ public abstract class CkPadlockComboBase<T> where T : IPadlockableRestriction
         };
 
         CkGui.InputTextRightIcon(passFieldLabel, leftWidth, passFieldHint, ref Password, maxLength, FAI.Key);
-        ImUtf8.SameLineInner();
         CkGui.InputTextRightIcon("##Timer_" + id, rightWidth, timerFieldHint, ref Timer, 12, FAI.Clock);
     }
 

--- a/ProjectGagSpeak/CustomCombos/Padlocks/PadlockGagsClient.cs
+++ b/ProjectGagSpeak/CustomCombos/Padlocks/PadlockGagsClient.cs
@@ -25,10 +25,10 @@ public class PadlockGagsClient : CkPadlockComboBase<ActiveGagSlot>
         => MonitoredItem.GagItem is GagType.None;
 
     public void DrawLockCombo(float width, int layerIdx, string tooltip)
-        => DrawLockCombo("ClientGagLock_"+ layerIdx, width, layerIdx, string.Empty, tooltip, false);
+        => DrawLockCombo("##ClientGagLock_"+ layerIdx, width, layerIdx, string.Empty, tooltip, false);
 
     public void DrawUnlockCombo(float width, int layerIdx, string tooltip)
-        => DrawUnlockCombo("ClientGagUnlock_" + layerIdx, width, layerIdx, string.Empty, tooltip);
+        => DrawUnlockCombo("##ClientGagUnlock_" + layerIdx, width, layerIdx, string.Empty, tooltip);
 
     protected override void OnLockButtonPress(int layerIdx)
     {

--- a/ProjectGagSpeak/CustomCombos/Padlocks/PadlockRestraintsClient.cs
+++ b/ProjectGagSpeak/CustomCombos/Padlocks/PadlockRestraintsClient.cs
@@ -27,10 +27,10 @@ public class PadlockRestraintsClient : CkPadlockComboBase<CharaActiveRestraint>
         => !MonitoredItem.CanLock() || MonitoredItem.Padlock == SelectedLock;
 
     public void DrawLockCombo(float width, string tooltip)
-    => DrawLockCombo("ClientRestraintLock", width, 0, string.Empty, tooltip, false);
+    => DrawLockCombo("##ClientRestraintLock", width, 0, string.Empty, tooltip, false);
 
     public void DrawUnlockCombo(float width, string tooltip)
-        => DrawUnlockCombo("ClientRestraintUnlock", width, 0, string.Empty, tooltip);
+        => DrawUnlockCombo("##ClientRestraintUnlock", width, 0, string.Empty, tooltip);
 
     protected override void OnLockButtonPress(int _)
     {

--- a/ProjectGagSpeak/CustomCombos/Padlocks/PadlockRestrictionsClient.cs
+++ b/ProjectGagSpeak/CustomCombos/Padlocks/PadlockRestrictionsClient.cs
@@ -28,10 +28,10 @@ public class PadlockRestrictionsClient : CkPadlockComboBase<ActiveRestriction>
         => MonitoredItem.CanLock() is false || MonitoredItem.Padlock == SelectedLock;
 
     public void DrawLockCombo(float width, int layerIdx, string tooltip)
-        => DrawLockCombo("ClientRestrictionLock", width, layerIdx, string.Empty, tooltip, true);
+        => DrawLockCombo("##ClientRestrictionLock", width, layerIdx, string.Empty, tooltip, true);
 
     public void DrawUnlockCombo(float width, int layerIdx, string tooltip)
-        => DrawUnlockCombo("ClientRestrictionUnlock", width, layerIdx, string.Empty, tooltip);
+        => DrawUnlockCombo("##ClientRestrictionUnlock", width, layerIdx, string.Empty, tooltip);
 
     protected override void OnLockButtonPress(int layerIdx)
     {

--- a/ProjectGagSpeak/UI/Components/Drawers/EquipmentDrawer.cs
+++ b/ProjectGagSpeak/UI/Components/Drawers/EquipmentDrawer.cs
@@ -311,22 +311,25 @@ public class EquipmentDrawer
     private void DrawItem(GlamourSlot item, float width, float innerWidthScaler)
     {
         // draw the item itemCombo.
-        var itemCombo = _itemCombos[item.Slot.ToIndex()];
-
-        var change = itemCombo.Draw(item.GameItem.Name, item.GameItem.ItemId, width, width * innerWidthScaler);
-
-        if (change && !item.GameItem.Equals(itemCombo.Current))
+        if (item.Slot != EquipSlot.Nothing)
         {
-            _logger.LogTrace($"Item changed from {itemCombo.Current} " +
-                $"[{itemCombo.Current.ItemId}] to {item.GameItem} [{item.GameItem.ItemId}]");
-            item.GameItem = itemCombo.Current;
-        }
+            var itemCombo = _itemCombos[item.Slot.ToIndex()];
 
-        if (ImGui.IsItemClicked(ImGuiMouseButton.Right))
-        {
-            _logger.LogTrace($"Item changed to {ItemService.NothingItem(item.Slot)} " +
-                $"[{ItemService.NothingItem(item.Slot).ItemId}] from {item.GameItem} [{item.GameItem.ItemId}]");
-            item.GameItem = ItemService.NothingItem(item.Slot);
+            var change = itemCombo.Draw(item.GameItem.Name, item.GameItem.ItemId, width, width * innerWidthScaler);
+
+            if (change && !item.GameItem.Equals(itemCombo.Current))
+            {
+                _logger.LogTrace($"Item changed from {itemCombo.Current} " +
+                    $"[{itemCombo.Current.ItemId}] to {item.GameItem} [{item.GameItem.ItemId}]");
+                item.GameItem = itemCombo.Current;
+            }
+
+            if (ImGui.IsItemClicked(ImGuiMouseButton.Right))
+            {
+                _logger.LogTrace($"Item changed to {ItemService.NothingItem(item.Slot)} " +
+                    $"[{ItemService.NothingItem(item.Slot).ItemId}] from {item.GameItem} [{item.GameItem.ItemId}]");
+                item.GameItem = ItemService.NothingItem(item.Slot);
+            }
         }
     }
 

--- a/ProjectGagSpeak/UI/Modules/Wardrobe/Panels/GagRestrictionsPanel.cs
+++ b/ProjectGagSpeak/UI/Modules/Wardrobe/Panels/GagRestrictionsPanel.cs
@@ -141,7 +141,7 @@ public partial class GagRestrictionsPanel
         wdl.AddRectFilled(minPos, minPos + new Vector2(size.X * .65f + styler.ItemInnerSpacing.Y, ImGui.GetFrameHeight() + styler.ItemInnerSpacing.Y), CkColor.SideButton.Uint(), rounding, ImDrawFlags.RoundCornersBottomRight);
 
         var pinkSize = new Vector2(size.X * .65f, ImGui.GetFrameHeight());
-        var hoveringTitle = ImGui.IsMouseHoveringRect(minPos + new Vector2(ImGui.GetFrameHeightWithSpacing()), minPos + pinkSize);
+        var hoveringTitle = ImGui.IsMouseHoveringRect(minPos + new Vector2(ImGui.GetFrameHeightWithSpacing(), 0), minPos + pinkSize);
         var col = hoveringTitle ? CkColor.VibrantPinkHovered.Uint() : CkColor.VibrantPink.Uint();
         wdl.AddRectFilled(minPos, minPos + pinkSize, col, rounding, ImDrawFlags.RoundCornersBottomRight);
 

--- a/ProjectGagSpeak/UI/Settings/SettingsUi.cs
+++ b/ProjectGagSpeak/UI/Settings/SettingsUi.cs
@@ -233,11 +233,6 @@ public class SettingsUi : WindowMediatorSubscriberBase
                     new KeyValuePair<string, object>(nameof(globals.RestrictionVisuals), restrictionVisuals), UpdateDir.Own)).ConfigureAwait(false);
             CkGui.HelpText(GSLoc.Settings.MainOptions.RestraintSetGlamourTT);
 
-            if (ImGui.Checkbox(GSLoc.Settings.MainOptions.RestraintSetGlamour, ref restraintSetVisuals))
-                _hub.UserUpdateOwnGlobalPerm(new(MainHub.PlayerUserData, MainHub.PlayerUserData, 
-                    new KeyValuePair<string, object>(nameof(globals.RestraintSetVisuals), restraintSetVisuals), UpdateDir.Own)).ConfigureAwait(false);
-            CkGui.HelpText(GSLoc.Settings.MainOptions.RestraintSetGlamourTT);
-
             if (ImGui.Checkbox(GSLoc.Settings.MainOptions.CursedLootActive, ref cursedDungeonLoot))
             {
                 _mainConfig.Config.CursedLootPanel = cursedDungeonLoot;


### PR DESCRIPTION
**SettingsUi.cs**
Duplicate Restraints Checkbox. One worked and the other did not. Tested the removal and now it only shows one and it checks correctly.

**GagRestrictionsPanel.cs**
Fixed the selection box for the gag editting.

**EquipmentDrawer.cs**
Out of bounds index check when opening the drawer for the first time when the slot is set to Nothing. 

**PadlockRestrictionsClient/PadlockRestraintsClient/PadlockGagsClient.cs**
Object labels being shown in the UI, offsetting the buttons

**CkPadlockComboBase.cs**
`var rightWidth = width - leftWidth - ImGui.GetStyle().ItemInnerSpacing.X;` =>`var rightWidth = leftWidth / 2f;`
This adjustment added a very small spacing to the back of the timer field for Restraints which slightly cut off the text. Makes the field look correctly rounded at the end.
` var unlockFieldWidth = width - buttonWidth - (ImGui.GetStyle().ItemInnerSpacing.X * 6);`
Adjusted the length of the unlock field to correctly fit the Key/Unlock icons after fixing the spacing in CkGui.Text

**CkGui.Text.cs**
The spacing here would create a massive gap between the InputText and Icon. Tested this change and it neatly places it next to the InputText and looks nice.