### PR TITLE
Fixes alt-account authentication deletion.

### DIFF
--- a/ProjectGagSpeak/Services/Config/ServerConfigManager.cs
+++ b/ProjectGagSpeak/Services/Config/ServerConfigManager.cs
@@ -149,20 +149,6 @@ public class ServerConfigManager
         auth.SecretKey.HasHadSuccessfulConnection = true;
         auth.SecretKey.LinkedProfileUID = connectedInfo.User.UID;
         _logger.LogDebug($"Updating authentication for {auth.CharacterName} with UID {connectedInfo.User.UID}");
-
-        // Now, we should iterate through each of our authentications.
-        foreach (var authentication in ServerStorage.Authentications)
-        {
-            // If the LinkedProfileUID is has a UID listed, but it's not in the list of auth UID's, remove the authentication.
-            if (!string.IsNullOrWhiteSpace(authentication.SecretKey.LinkedProfileUID))
-            {
-                if (!connectedInfo.ActiveAccountUidList.Contains(authentication.SecretKey.LinkedProfileUID))
-                {
-                    ServerStorage.Authentications.Remove(authentication);
-                    continue;
-                }
-            }
-        }
         Save();
     }
 


### PR DESCRIPTION
Currently, as written, the code will delete any accounts not found in the connectionDto, but the connectionDto only returns the current profileUID. If we want to mark them as stale, we could, but it is not necessary to delete them. Should leave it up to the users since it has the potential to delete the main account at present.

_Technically_ the bug is in the server GagspeakHub.cs:118, but I don't see a good way to fix this elegantly on the server side. It doesn't do any harm to leave stale user accounts on the client either (they can delete them manually as needed).