### PR TITLE
Fixes bug related to game stains not applying from restriction layers.

### DIFF
--- a/ProjectGagSpeak/State/_Models/Restrictions/RestrictionElements.cs
+++ b/ProjectGagSpeak/State/_Models/Restrictions/RestrictionElements.cs
@@ -43,7 +43,7 @@ public class GlamourSlot : IEquatable<GlamourSlot>
         => (Slot, GameItem) = (slot, gameItem);
 
     public GlamourSlot(EquipSlot slot, EquipItem item, StainIds dyes)
-    => (Slot, GameItem, dyes) = (slot, item, dyes);
+    => (Slot, GameItem, GameStain) = (slot, item, dyes);
 
     public JObject Serialize()
         => new JObject


### PR DESCRIPTION
Essentially before it wouldn't copy the game stains from the restriction layers. Took a bit of tracing to find, but it's in the specific constructor used when a restriction layer is applied to a restraint set.