### PR TITLE
Fixed redraw not saving for restrictions.

### DIFF
--- a/ProjectGagSpeak/State/_Models/Restrictions/Restrictions.cs
+++ b/ProjectGagSpeak/State/_Models/Restrictions/Restrictions.cs
@@ -203,7 +203,7 @@ public class RestrictionItem : IEditableStorageItem<RestrictionItem>, IRestricti
             ["VisorState"] = VisorState.ToString(),
             ["Traits"] = Traits.ToString(),
             ["Arousal"] = Arousal.ToString(),
-            ["Redraw"] = DoRedraw,
+            ["DoRedraw"] = DoRedraw,
         };
 
     public LightRestriction ToLightItem()


### PR DESCRIPTION
Changed the saved variable name to "DoRedraw" for consistency.
Config shouldn't be lost with this change, as it could only ever save false for the value in the first place.