### PR TITLE
fix updating nameplates when gags change

### DIFF
--- a/ProjectGagSpeak/PlayerKinkster/Kinkster.cs
+++ b/ProjectGagSpeak/PlayerKinkster/Kinkster.cs
@@ -269,6 +269,9 @@ public class Kinkster : IComparable<Kinkster>
             LightCache = new KinksterCache(data.LightStorageData);
         }
 
+        // Notify nameplates of visible kinkster gag changes.
+        _mediator.Publish(new KinksterActiveGagsChanged(this));
+
         // Deterministic AliasData setting.
         if (data.PairAliasData.TryGetValue(UserData.UID, out var match))
         {
@@ -319,6 +322,9 @@ public class Kinkster : IComparable<Kinkster>
                 UpdateCachedLockedSlots();
                 return;
         }
+
+        // Notify nameplates of visible kinkster gag changes.
+        _mediator.Publish(new KinksterActiveGagsChanged(this));
     }
 
     public void NewActiveRestrictionData(KinksterUpdateActiveRestriction data)

--- a/ProjectGagSpeak/ProjectGagSpeak.csproj
+++ b/ProjectGagSpeak/ProjectGagSpeak.csproj
@@ -38,7 +38,7 @@
     <ItemGroup>
         <!--Submodules-->
         <ProjectReference Include="..\CkCommons\CkCommons.csproj" />
-        <ProjectReference Include="..\GagspeakAPI\ProjectGagspeakAPI.csproj" />
+        <ProjectReference Include="..\GagspeakAPI\ProjectGagspeakAPI.csproj" GlobalPropertiesToRemove="Platform" />
         <ProjectReference Include="..\OtterGui\OtterGui.csproj" />
         <ProjectReference Include="..\Penumbra.Api\Penumbra.Api.csproj" />
         <ProjectReference Include="..\Penumbra.String\Penumbra.String.csproj" />

--- a/ProjectGagSpeak/Services/Mediator/Messages/Messages.PlayerData.cs
+++ b/ProjectGagSpeak/Services/Mediator/Messages/Messages.PlayerData.cs
@@ -9,6 +9,7 @@ public record KinksterOnline(Kinkster Kinkster) : MessageBase; // Revise
 public record KinksterOffline(Kinkster Kinkster) : MessageBase;
 public record KinksterPlayerRendered(KinksterHandler Handler, Kinkster Kinkster) : SameThreadMessage; // Effectively "becoming visible"
 public record KinksterPlayerUnrendered(IntPtr Address) : SameThreadMessage; // Effectively "becoming invisible"
+public record KinksterActiveGagsChanged(Kinkster Kinkster) : SameThreadMessage; // when the active gags of a kinkster change.
 
 public record KinksterRemovedMessage(UserData UserData) : MessageBase; // a message indicating a pair has been removed.
 public record TargetKinksterMessage(Kinkster Kinkster) : MessageBase; // called when publishing a targeted pair connection (see UI)

--- a/ProjectGagSpeak/Services/NameplateService.cs
+++ b/ProjectGagSpeak/Services/NameplateService.cs
@@ -36,8 +36,8 @@ public sealed class NameplateService : DisposableMediatorSubscriberBase
     private IDalamudTextureWrap GaggedIcon;
     private IDalamudTextureWrap GaggedSpeakingIcon;
 
-    public NameplateService(ILogger<NameplateService> logger, GagspeakMediator mediator, MainConfig config, 
-        GagRestrictionManager gags,  GagspeakEventManager events, KinksterManager kinksters)
+    public NameplateService(ILogger<NameplateService> logger, GagspeakMediator mediator, MainConfig config,
+        GagRestrictionManager gags, GagspeakEventManager events, KinksterManager kinksters)
         : base(logger, mediator)
     {
         _config = config;
@@ -57,6 +57,8 @@ public sealed class NameplateService : DisposableMediatorSubscriberBase
 
         Mediator.Subscribe<KinksterPlayerRendered>(this, _ => UpdateGaggedKinksters());
         Mediator.Subscribe<KinksterPlayerUnrendered>(this, _ => UpdateGaggedKinksters());
+        Mediator.Subscribe<KinksterActiveGagsChanged>(this, m =>
+            UpdateKinkster(0, 0, m.Kinkster.IsRendered && m.Kinkster.ActiveGags.IsGagged() && m.Kinkster.PairGlobals.ChatGarblerActive, string.Empty, m.Kinkster));
         Mediator.Subscribe<ChatboxMessageFromSelf>(this, m => OnOwnMessage(m.channel, m.message));
         Mediator.Subscribe<ChatboxMessageFromKinkster>(this, m => OnKinksterMessage(m.kinkster, m.channel, m.message));
         Mediator.Subscribe<ConnectedMessage>(this, _ => RefreshClientGagState());
@@ -204,7 +206,7 @@ public sealed class NameplateService : DisposableMediatorSubscriberBase
             // Skip if not player character, if if the player character is null.
             if (h.NamePlateKind is not NamePlateKind.PlayerCharacter)
                 continue;
-            
+
             if (h.PlayerCharacter is not { } pc)
                 continue;
 
@@ -232,7 +234,7 @@ public sealed class NameplateService : DisposableMediatorSubscriberBase
 
     private unsafe void LoadTextureToAsset(AtkImageNode* node, AtkResNode* parentNode, bool isSpeaking)
     {
-        var texturePointer = (Texture*)Svc.Texture.ConvertToKernelTexture(isSpeaking ? GaggedSpeakingIcon: GaggedIcon, true);
+        var texturePointer = (Texture*)Svc.Texture.ConvertToKernelTexture(isSpeaking ? GaggedSpeakingIcon : GaggedIcon, true);
         // Update the actual width to be reflected in resolution
         texturePointer->ActualWidth = 32;
         texturePointer->ActualHeight = 32;


### PR DESCRIPTION
currently if active gags are changed by someone other than you, the icons in nameplates do not update. This change notifies nameplateservice whenever activegags change, whether by paired kinkster or a 3rd party.