### PR TITLE
fix moodles ipc

### DIFF
--- a/ProjectGagSpeak/Interop/Ipc/IpcCallerMoodles.cs
+++ b/ProjectGagSpeak/Interop/Ipc/IpcCallerMoodles.cs
@@ -57,9 +57,9 @@ public sealed class IpcCallerMoodles : IIpcCaller
         // API Enactors
         SetStatusManagerByPtr = Svc.PluginInterface.GetIpcSubscriber<nint, string, object>("Moodles.SetStatusManagerByPtrV2");
         ClearStatusMangerByPtr = Svc.PluginInterface.GetIpcSubscriber<nint, object>("Moodles.ClearStatusManagerByPtrV2");
-        ApplyStatusByPtr = Svc.PluginInterface.GetIpcSubscriber<Guid, nint, object>("Moodles.AddOrUpdateStatusByPtrV2");
+        ApplyStatusByPtr = Svc.PluginInterface.GetIpcSubscriber<Guid, nint, object>("Moodles.AddOrUpdateMoodleByPtrV2");
         ApplyPresetByPtr = Svc.PluginInterface.GetIpcSubscriber<Guid, nint, object>("Moodles.ApplyPresetByPtrV2");
-        RemoveStatusesByPtr = Svc.PluginInterface.GetIpcSubscriber<List<Guid>, nint, object>("Moodles.RemoveStatusesByPtrV2");
+        RemoveStatusesByPtr = Svc.PluginInterface.GetIpcSubscriber<List<Guid>, nint, object>("Moodles.RemoveMoodlesByPtrV2");
 
         // API Action Events:
         OnStatusManagerModified = Svc.PluginInterface.GetIpcSubscriber<nint, object>("Moodles.StatusManagerModified");

--- a/ProjectGagSpeak/Services/ArousalService.cs
+++ b/ProjectGagSpeak/Services/ArousalService.cs
@@ -1,12 +1,12 @@
 using CkCommons;
+using CkCommons.Gui;
+using Dalamud.Bindings.ImGui;
+using Dalamud.Interface.Colors;
+using Dalamud.Interface.Utility.Raii;
 using GagSpeak.State.Caches;
 using GagSpeak.Utils;
 using GagspeakAPI.Attributes;
-using Dalamud.Bindings.ImGui;
 using OtterGui;
-using Dalamud.Interface.Utility.Raii;
-using Dalamud.Interface.Colors;
-using CkCommons.Gui;
 
 namespace GagSpeak.Services;
 
@@ -145,6 +145,8 @@ public sealed class ArousalService : IDisposable
         // Decay: usually a fraction of generation
         _degenerationRate = _generationRate * 0.5f;
 
+        _logger.LogDebug("Finished Updating Arousal Caches.", LoggerType.Arousal);
+
         return Task.CompletedTask;
     }
     #endregion Public Methods
@@ -216,19 +218,19 @@ public sealed class ArousalService : IDisposable
         ImGui.TextUnformatted($"Degeneration Rate: {_degenerationRate}");
         ImGui.Separator();
         ImGui.TextUnformatted("Arousal Effects:");
-        
+
         ImGui.Text("Blur:");
         CkGui.ColorTextInline(DoScreenBlur.ToString(), DoScreenBlur ? ImGuiColors.ParsedPink : ImGuiColors.ParsedGreen);
         CkGui.TextInline($"| Intensity: {BlurIntensity:P2}");
-        
+
         ImGui.Text("Blush:");
         CkGui.ColorTextInline(DoBlush.ToString(), DoBlush ? ImGuiColors.ParsedPink : ImGuiColors.ParsedGreen);
         CkGui.TextInline($"| Opacity: {BlushOpacity:P2}");
-        
+
         ImGui.Text("Stutter:");
         CkGui.ColorTextInline(DoStutter.ToString(), DoStutter ? ImGuiColors.ParsedPink : ImGuiColors.ParsedGreen);
         CkGui.TextInline($"| Frequency: {StutterFrequency:P2}");
-        
+
         ImGui.Text("Pulse:");
         CkGui.ColorTextInline(DoPulse.ToString(), DoPulse ? ImGuiColors.ParsedPink : ImGuiColors.ParsedGreen);
         CkGui.TextInline($"| Rate: {PulseRate:P2}");

--- a/ProjectGagSpeak/State/Handlers/CustomizePlusHandler.cs
+++ b/ProjectGagSpeak/State/Handlers/CustomizePlusHandler.cs
@@ -50,6 +50,7 @@ public class CustomizePlusHandler
             _logger.LogDebug("Ensuring C+ is locked in the correct state.", LoggerType.VisualCache);
             await ApplyProfileCache();
         }
+        _logger.LogDebug("Finished Updating C+ Caches.", LoggerType.VisualCache);
     }
 
     public void EnsureRestrictedProfile()

--- a/ProjectGagSpeak/State/Handlers/GlamourHandler.cs
+++ b/ProjectGagSpeak/State/Handlers/GlamourHandler.cs
@@ -7,6 +7,7 @@ using Penumbra.GameData.Enums;
 using Penumbra.GameData.Structs;
 
 namespace GagSpeak.State.Handlers;
+
 public class GlamourHandler
 {
     private readonly ILogger<GlamourHandler> _logger;
@@ -118,6 +119,7 @@ public class GlamourHandler
             );
             _logger.LogInformation($"Processed Cache Updates Successfully!");
         });
+        _logger.LogDebug("Finished Updating Glamourer Caches.");
     }
 
 

--- a/ProjectGagSpeak/State/Handlers/ModHandler.cs
+++ b/ProjectGagSpeak/State/Handlers/ModHandler.cs
@@ -74,6 +74,7 @@ public class ModHandler
         }
         else
             _logger.LogTrace("No change in FinalMods Cache.", LoggerType.VisualCache);
+        _logger.LogDebug("Finished Updating Mod Caches.", LoggerType.VisualCache);
     }
 
     /// <summary>
@@ -126,7 +127,7 @@ public class ModHandler
             _logger.LogWarning($"Failed to remove ModPreset [{modPreset.Label}] for mod [{modPreset.Container.ModName}].");
         else
             _logger.LogDebug($"Removed ModPreset [{modPreset.Label}] for mod [{modPreset.Container.ModName}].");
-     }
+    }
 
     /// <summary> Removes multiple temporary mods with a lock, or updates the existing locked mods temporary settings. </summary>
     /// <returns> If the operation was successful for all <paramref name="modPresets"/></returns>
@@ -140,7 +141,7 @@ public class ModHandler
     /// <returns> If the operation was successful. </returns>
     private void RemoveAllTempMods(bool redraw = false)
     {
-        if(_ipc.ClearAllTemporaryMods() is PenumbraApiEc.Success)
+        if (_ipc.ClearAllTemporaryMods() is PenumbraApiEc.Success)
             _logger.LogDebug("Successfully cleared all temporary mods.");
         else
             _logger.LogWarning("Failed to clear all temporary mods.");

--- a/ProjectGagSpeak/State/Handlers/MoodleHandler.cs
+++ b/ProjectGagSpeak/State/Handlers/MoodleHandler.cs
@@ -67,7 +67,7 @@ public class MoodleHandler
         // Update the final cache. `removedSlots` contains slots that are no longer restricted after the change.
         if (_cache.UpdateFinalCache(out var removedMoodles))
         {
-            _logger.LogDebug($"FinalMoodles Cache was updated!", LoggerType.VisualCache);
+            _logger.LogDebug($"FinalMoodles Cache was updated! RemovedMoodles: {removedMoodles.Count()}", LoggerType.VisualCache);
             if (removedMoodles.Any())
                 await RestoreAndReapplyCache(removedMoodles);
             else
@@ -75,6 +75,7 @@ public class MoodleHandler
         }
         else
             _logger.LogTrace("No change in FinalMoodles Cache.", LoggerType.VisualCache);
+        _logger.LogDebug("Finished Updating Moodle Caches.", LoggerType.VisualCache);
     }
 
     /// <summary>

--- a/ProjectGagSpeak/State/Handlers/OverlayHandler.cs
+++ b/ProjectGagSpeak/State/Handlers/OverlayHandler.cs
@@ -32,14 +32,14 @@ public class OverlayHandler : DisposableMediatorSubscriberBase
     }
 
     public static bool SentEffectValid { get; private set; } = false;
-    
+
     // when we need to reapply an effect after a login on a character with an active one.
     public async Task ReapplySavedActiveEffect()
     {
         // Method should only be called once we have verified that we have an effect that should be applied and active,
         // and the timer is still running.
         Logger.LogDebug("Reapplying set hypnotic effect after reconnection!");
-        
+
         // if any part of this load is invalid, we should invalidate the sent effect, and return.
         if (ClientData.Hardcore is not { } hs)
             return;
@@ -92,7 +92,7 @@ public class OverlayHandler : DisposableMediatorSubscriberBase
         // otherwise it is valid so set the time.
         if (!await _hypnoService.ApplyEffect(effect, enactor.UID, customImage))
             throw new Bagagwa("Summoned Bagagwa while setting a timed hypnotic effect! This should never happen!");
-        
+
         Logger.LogInformation($"Timed Hypnosis Effect successfully applied!", LoggerType.VisualCache);
         // Achievements here maybe.
 
@@ -173,6 +173,7 @@ public class OverlayHandler : DisposableMediatorSubscriberBase
             );
             Logger.LogInformation($"Processed Cache Updates Successfully!");
         });
+        Logger.LogDebug("Finished Updating Overlay Caches.", LoggerType.VisualCache);
     }
 
 

--- a/ProjectGagSpeak/State/Handlers/TraitsHandler.cs
+++ b/ProjectGagSpeak/State/Handlers/TraitsHandler.cs
@@ -58,6 +58,7 @@ public class TraitsHandler
         }
         else
             _logger.LogTrace("No change in Final Traits.", LoggerType.VisualCache);
+        _logger.LogDebug("Finished Updating Traits Caches.", LoggerType.VisualCache);
 
         return Task.CompletedTask;
     }


### PR DESCRIPTION
Fix moodles IPC names:
- Fixes achievement data not loading, as an exception from moodles caught by the connection process stops the data loading short.
- Fixes crashing on plugin unload and character logout.
- Adds debug logs to when cache updates finish, helping find halted cache updates in the future.