### PR TITLE
disable UI that isnt ready for use

### DIFF
--- a/ProjectGagSpeak/UI/Components/TabBars/ImageTabBar/WardrobeTabs.cs
+++ b/ProjectGagSpeak/UI/Components/TabBars/ImageTabBar/WardrobeTabs.cs
@@ -21,7 +21,10 @@ public class WardrobeTabs : ImageTabBar<WardrobeTabs.SelectedTab>
             "Restrictions--SEP--Apply, Lock, Unlock, Remove, or Configure your various Restrictions");
         AddDrawButton(CosmeticService.CoreTextures.Cache[CoreTexture.Gagged], SelectedTab.MyGags,
             "Gags--SEP--Apply, Lock, Unlock, Remove, or Configure your various Gags");
+#if DEBUG
+        // TODO: enable in release when collar management is implemented
         AddDrawButton(CosmeticService.CoreTextures.Cache[CoreTexture.Collar], SelectedTab.MyCollar,
             "My Collar--SEP--Setup your Collar, and manage incoming and outgoing collar requests.");
+#endif
     }
 }

--- a/ProjectGagSpeak/UI/MainUi/MainUI.cs
+++ b/ProjectGagSpeak/UI/MainUi/MainUI.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+using System.Reflection;
 using CkCommons.Gui;
 using Dalamud.Bindings.ImGui;
 using Dalamud.Interface.Colors;
@@ -13,8 +15,6 @@ using GagSpeak.Utils;
 using GagSpeak.WebAPI;
 using GagspeakAPI.Hub;
 using OtterGui.Text;
-using System.Globalization;
-using System.Reflection;
 
 namespace GagSpeak.Gui.MainWindow;
 
@@ -47,9 +47,9 @@ public class MainUI : WindowMediatorSubscriberBase
     private bool ThemePushed = false;
 
     public MainUI(ILogger<MainUI> logger, GagspeakMediator mediator, MainConfig config,
-        AccountManager account, MainHub hub, MainMenuTabs tabMenu, SidePanelService sidePanel, RequestsManager requestmanager, 
+        AccountManager account, MainHub hub, MainMenuTabs tabMenu, SidePanelService sidePanel, RequestsManager requestmanager,
         KinksterManager kinksters, TutorialService guides, HomeTab home, RequestsTab requests,
-        WhitelistTab whitelist, PatternHubTab patternHub, MoodleHubTab moodlesHub, GlobalChatTab globalChat)         
+        WhitelistTab whitelist, PatternHubTab patternHub, MoodleHubTab moodlesHub, GlobalChatTab globalChat)
         : base(logger, mediator, "###GagSpeakMainUI")
     {
         _config = config;
@@ -69,7 +69,7 @@ public class MainUI : WindowMediatorSubscriberBase
 
         // display info about the folders
         var ver = Assembly.GetExecutingAssembly().GetName().Version!;
-        WindowName = $"GagSpeak Closed Beta ({ver.Major}.{ver.Minor}.{ver.Build}.{ver.Revision})###GagSpeakMainUI";
+        WindowName = $"GagSpeak Open Beta ({ver.Major}.{ver.Minor}.{ver.Build}.{ver.Revision})###GagSpeakMainUI";
         Flags |= WFlags.NoDocking;
 
         this.PinningClickthroughFalse();
@@ -80,9 +80,9 @@ public class MainUI : WindowMediatorSubscriberBase
             .Add(FAI.Bell, "Actions Notifier", () => Mediator.Publish(new UiToggleMessage(typeof(InteractionEventsUI))))
             .AddTutorial(_guides, TutorialType.MainUi)
             .Build();
-        
+
         // Default to open if the user desires for it to be open.
-        if(_config.Current.OpenMainUiOnStartup)
+        if (_config.Current.OpenMainUiOnStartup)
             Toggle();
         // Update the tab menu selection.
         _tabMenu.TabSelection = _config.Current.MainUiTab;
@@ -179,7 +179,7 @@ public class MainUI : WindowMediatorSubscriberBase
                     break;
                 case MainMenuTabs.SelectedTab.PatternHub:
                     _patternHub.DrawPatternHub();
-                    _guides.OpenTutorial(TutorialType.MainUi, StepsMainUi.PatternResults, ImGui.GetWindowPos(), ImGui.GetWindowSize(), 
+                    _guides.OpenTutorial(TutorialType.MainUi, StepsMainUi.PatternResults, ImGui.GetWindowPos(), ImGui.GetWindowSize(),
                         () => { _tabMenu.TabSelection = MainMenuTabs.SelectedTab.MoodlesHub; });
                     break;
                 case MainMenuTabs.SelectedTab.MoodlesHub:
@@ -270,7 +270,7 @@ public class MainUI : WindowMediatorSubscriberBase
         var textSize = ImGui.CalcTextSize("Kinksters Online");
         var serverText = "Main GagSpeak Server";
         var shardTextSize = ImGui.CalcTextSize(serverText);
-        var totalHeight = ImGui.GetTextLineHeight()*2 + ImGui.GetStyle().ItemSpacing.Y;
+        var totalHeight = ImGui.GetTextLineHeight() * 2 + ImGui.GetStyle().ItemSpacing.Y;
 
         // create a table
         ImGui.SetCursorPosY(ImGui.GetCursorPosY() - ImGui.GetStyle().ItemSpacing.Y);

--- a/ProjectGagSpeak/UI/MainUi/SidePanel/SidePanelKinkster/SidePanelPair.Hardcore.cs
+++ b/ProjectGagSpeak/UI/MainUi/SidePanel/SidePanelKinkster/SidePanelPair.Hardcore.cs
@@ -44,12 +44,14 @@ public partial class SidePanelPair
 
         // ------ Locked Emote State ------
         var emoteActive = hc.LockedEmoteState.Length > 0;
-        var emoteInfo = emoteActive ? (FAI.StopCircle, $"Free {dispName}'s Locked Emote State.") : k.PairPerms.AllowLockedEmoting 
+        var emoteInfo = emoteActive ? (FAI.StopCircle, $"Free {dispName}'s Locked Emote State.") : k.PairPerms.AllowLockedEmoting
             ? (FAI.PersonArrowDownToLine, $"Force {dispName}'s Emote State.") : (FAI.Chair, $"Force {dispName} to Sit.");
         var emoteDis = (!k.PairPerms.AllowLockedSitting && !k.PairPerms.AllowLockedEmoting) || !hc.CanChange(HcAttribute.EmoteState, MainHub.UID);
         DrawColoredExpander(InteractionType.LockedEmoteState, emoteInfo.Item1, emoteInfo.Item2, emoteActive, emoteDis, emoteInfo.Item2);
         UniqueHcChild(InteractionType.LockedEmoteState, emoteActive, CkStyle.TwoRowHeight(), () => DrawEmoteChild(cache, k, dispName, width, emoteDis));
 
+#if DEBUG
+        // TODO: enable in release when confinement works
         // ------ Locked Confinement ------
         var confinementActive = hc.IndoorConfinement.Length > 0;
         var confinementInfo = confinementActive ? (FAI.StopCircle, $"Release {dispName} from Confinement.") : (FAI.HouseLock, $"Lock {dispName} away indoors.");
@@ -61,6 +63,7 @@ public partial class SidePanelPair
             DrawTimerButtonRow(InteractionType.Confinement, ref cache.ConfinementTimer, "Confine", !confinementAllowed);
             DrawAddressConfig(cache, k, dispName, width);
         });
+#endif
 
         // ------ Locked Imprisonment ------
         var imprisonmentActive = hc.Imprisonment.Length > 0;
@@ -152,7 +155,7 @@ public partial class SidePanelPair
         {
             if (cache.OpenItem != type)
                 return;
-            
+
             using (ImRaii.Child($"{type}Child", new Vector2(width, ImGui.GetFrameHeight())))
             {
                 if (curState)
@@ -224,7 +227,7 @@ public partial class SidePanelPair
             {
                 // reset cycle pose back to 0 if the emote doesn't have it.
                 cache.CyclePose = 0;
-                if(cache.Emotes.Draw("##LockedLoopEmoteCombo", cache.EmoteId, width, 1.3f))
+                if (cache.Emotes.Draw("##LockedLoopEmoteCombo", cache.EmoteId, width, 1.3f))
                 {
                     cache.EmoteId = cache.Emotes.Current.RowId;
                     Svc.Logger.Information($"Changed EmoteID to {cache.EmoteId} for {dispName}.");
@@ -291,7 +294,7 @@ public partial class SidePanelPair
 
         // draw out the sliders based on the property type.
         ImUtf8.SameLineInner();
-        var sliderW = propType is not PropertyType.PrivateChambers 
+        var sliderW = propType is not PropertyType.PrivateChambers
             ? ImGui.GetContentRegionAvail().X : (ImGui.GetContentRegionAvail().X - ImGui.GetStyle().ItemInnerSpacing.X) / 2;
         switch (propType)
         {

--- a/ProjectGagSpeak/UI/MainUi/Tabs/HomeTab.cs
+++ b/ProjectGagSpeak/UI/MainUi/Tabs/HomeTab.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using CkCommons;
 using CkCommons.Gui;
 using CkCommons.Raii;
@@ -18,7 +19,6 @@ using GagSpeak.Services.Textures;
 using GagSpeak.Services.Tutorial;
 using GagSpeak.WebAPI;
 using OtterGui.Text;
-using System.Globalization;
 
 namespace GagSpeak.Gui.MainWindow;
 
@@ -40,7 +40,7 @@ public class HomeTab
 
     private bool _editingSafeword = false;
 
-    public HomeTab(GagspeakMediator mediator, MainConfig config, 
+    public HomeTab(GagspeakMediator mediator, MainConfig config,
         KinkPlateService service, TutorialService guides)
     {
         _mediator = mediator;
@@ -132,7 +132,7 @@ public class HomeTab
             if (ImGui.InvisibleButton("##EditProfileButton", EditBorderSize))
                 _mediator.Publish(new UiToggleMessage(typeof(KinkPlateEditorUI)));
             CkGui.AttachToolTip("Open and Customize your KinkPlate™!");
-            
+
             _guides.OpenTutorial(TutorialType.MainUi, StepsMainUi.ProfileEditing, LastWinPos, LastWinSize,
                 () => _mediator.Publish(new UiToggleMessage(typeof(KinkPlateEditorUI))));
 
@@ -171,10 +171,10 @@ public class HomeTab
     private void DrawSafewordRow(float width)
     {
         using var _ = ImRaii.Group();
-        
+
         CkGui.IconTextAligned(FAI.HandPaper);
         using var font = ImRaii.PushFont(UiBuilder.MonoFont);
-        
+
         if (_editingSafeword)
         {
             ImGui.SameLine();
@@ -268,9 +268,14 @@ public class HomeTab
 
     private void SexToyRemoteButton(float width)
     {
-        if (CkGui.FancyButton(FAI.WaveSquare, "Sex Toy Remote", width, false))
+        var disabled = true;
+#if DEBUG
+        // TODO: Remove when this works
+        disabled = false;
+#endif
+        if (CkGui.FancyButton(FAI.WaveSquare, "Sex Toy Remote", width, disabled))
             _mediator.Publish(new UiToggleMessage(typeof(BuzzToyRemoteUI)));
-        CkGui.AttachToolTip("Control Simulated, or IRL Sex Toys!");
+        CkGui.AttachToolTip("Control Simulated, or IRL Sex Toys! --COL--[WIP]--COL--");
     }
 
     private void WardrobeButton(float width)
@@ -289,16 +294,26 @@ public class HomeTab
 
     private void PuppeteerButton(float width)
     {
-        if (CkGui.FancyButton(FAI.PersonHarassing, "Puppeteer", width, false))
+        var disabled = true;
+#if DEBUG
+        // TODO: Remove when this works
+        disabled = false;
+#endif
+        if (CkGui.FancyButton(FAI.PersonHarassing, "Puppeteer", width, disabled))
             _mediator.Publish(new UiToggleMessage(typeof(PuppeteerUI)));
-        CkGui.AttachToolTip("Who's in control now? (Global & Per-Kinkster Control)");
+        CkGui.AttachToolTip("Who's in control now? (Global & Per-Kinkster Control) --COL--[WIP]--COL--");
     }
 
     private void ToyboxButton(float width)
     {
-        if (CkGui.FancyButton(FAI.BoxOpen, "Toybox", width, false))
+        var disabled = true;
+#if DEBUG
+        // TODO: Remove when this works
+        disabled = false;
+#endif
+        if (CkGui.FancyButton(FAI.BoxOpen, "Toybox", width, disabled))
             _mediator.Publish(new UiToggleMessage(typeof(ToyboxUI)));
-        CkGui.AttachToolTip("Patterns, Alarms, Triggers, VibeLobbies, Toys and more!");
+        CkGui.AttachToolTip("Patterns, Alarms, Triggers, VibeLobbies, Toys and more! --COL--[WIP]--COL--");
     }
 
     private void ModPresetsButton(float width)
@@ -311,9 +326,14 @@ public class HomeTab
 
     private void AllowancesButton(float width)
     {
-        if (CkGui.FancyButton(FAI.UserShield, "Trait Allowances", width, false))
+        var disabled = true;
+#if DEBUG
+        // TODO: Remove when this works
+        disabled = false;
+#endif
+        if (CkGui.FancyButton(FAI.UserShield, "Trait Allowances", width, disabled))
             _mediator.Publish(new UiToggleMessage(typeof(AllowancesUI)));
-        CkGui.AttachToolTip("Control who has access to view your various Data!");
+        CkGui.AttachToolTip("Control who has access to view your various Data! --COL--[WIP]--COL--");
     }
 
     private void PublicationsButton(float width)


### PR DESCRIPTION
Main menu disables buttons that aren't ready:

<img width="358" height="207" alt="image" src="https://github.com/user-attachments/assets/ffa5f6c3-474c-4459-9148-57a2672b4812" />


Wardrobe tabs hide collar management:

<img width="297" height="75" alt="image" src="https://github.com/user-attachments/assets/319dd90f-9f57-4d9f-9f68-d66f14513a23" />
