### PR TITLE
Tutorial Button Safety Checks

### DIFF
--- a/ProjectGagSpeak/Localization/Strings.cs
+++ b/ProjectGagSpeak/Localization/Strings.cs
@@ -54,6 +54,7 @@ namespace GagSpeak.Localization
         public HelpRestraints Restraints { get; set; } = new();
         public HelpRestrictions Restrictions { get; set; } = new();
         public HelpGags Gags { get; set; } = new();
+        public HelpCollar Collar { get; set; } = new();
         public HelpCursedLoot CursedLoot { get; set; } = new();
         public HelpPuppeteer Puppeteer { get; set; } = new();
         public HelpToys Toys { get; set; } = new();
@@ -62,6 +63,7 @@ namespace GagSpeak.Localization
         public HelpAlarms Alarms { get; set; } = new();
         public HelpTriggers Triggers { get; set; } = new();
         public HelpAchievements Achievements { get; set; } = new();
+        public HelpModPresets ModPresets { get; set; } = new();
     }
 
     public class HelpMainUi
@@ -655,6 +657,11 @@ namespace GagSpeak.Localization
         public readonly string Step25DescExtended = Loc.Localize("HelpGags_Step25DescExtended", " ");
     }
 
+    public class HelpCollar
+    {
+
+    }
+
     public class HelpCursedLoot
     {
         //public readonly string Step1Title = Loc.Localize("HelpCursedLoot_Step1Title", "Creating Cursed Items");
@@ -1004,6 +1011,11 @@ namespace GagSpeak.Localization
         public readonly string Step6Title = Loc.Localize("HelpAchievements_Step6Title", "Achievement Rewards");
         public readonly string Step6Desc = Loc.Localize("HelpAchievements_Step6Desc", "Achievement Rewards come in the form of profile cosmetic customizations, in addition to your title, and can be previewed here.");
         public readonly string Step6DescExtended = Loc.Localize("HelpAchievements_Step6DescExtended", "Cosmetic rewards can be used to decorate your profile in the profile editor.");
+    }
+
+    public class HelpModPresets
+    {
+
     }
 
     #endregion Tutorials

--- a/ProjectGagSpeak/Services/Tutorial/TutorialService.cs
+++ b/ProjectGagSpeak/Services/Tutorial/TutorialService.cs
@@ -35,6 +35,14 @@ public class TutorialService
     public bool IsTutorialActive(TutorialType type)
         => _tutorials[type].Cache.CurrentStep is not -1;
 
+    /// <summary>
+    /// Checks if a <see cref="TutorialType"/> tutorial has been added to the service's dictionary.
+    /// </summary>
+    /// <param name="type">The <see cref="TutorialType"/> key to look for in the dictionary.</param>
+    /// <returns><see langword="true"/> if the type has been added, otherwise false.</returns>
+    public bool Exists(TutorialType type)
+        => _tutorials.ContainsKey(type);
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void StartTutorial(TutorialType guide)
     {
@@ -86,6 +94,7 @@ public class TutorialService
         { TutorialType.Restraints, Enum.GetValues<StepsRestraints>().Length },
         { TutorialType.Restrictions, Enum.GetValues<StepsRestrictions>().Length },
         { TutorialType.Gags, Enum.GetValues<StepsGags>().Length },
+        { TutorialType.Collar, Enum.GetValues<StepsGags>().Length },
         { TutorialType.CursedLoot, Enum.GetValues<StepsCursedLoot>().Length },
         { TutorialType.Puppeteer, Enum.GetValues<StepsPuppeteer>().Length },
         { TutorialType.Toys, Enum.GetValues<StepsToys>().Length },
@@ -94,6 +103,7 @@ public class TutorialService
         { TutorialType.Triggers, Enum.GetValues<StepsTriggers>().Length },
         { TutorialType.Alarms, Enum.GetValues<StepsAlarms>().Length },
         { TutorialType.Achievements, Enum.GetValues<StepsAchievements>().Length },
+        { TutorialType.ModPresets, Enum.GetValues<StepsModPresets>().Length },
     };
 
     public void InitializeTutorialStrings()
@@ -275,6 +285,15 @@ public class TutorialService
         .AddStep(gagsStr.Step25Title, gagsStr.Step25Desc, gagsStr.Step25DescExtended)
         .EnsureSize(TutorialSizes[TutorialType.Gags]);
 
+        var collarStr = GSLoc.Tutorials.Collar;
+        _tutorials[TutorialType.Collar] = new Tutorial("Collar Tutorial")
+            .WithCache(new GuideCache()
+            {
+                BorderColor = ImGui.GetColorU32(ImGuiColors.TankBlue),
+                HighlightColor = ImGui.GetColorU32(ImGuiColors.TankBlue),
+            })
+            .EnsureSize(0);
+
         var cursedLootStr = GSLoc.Tutorials.CursedLoot;
         _tutorials[TutorialType.CursedLoot] = new Tutorial("Cursed Loot Tutorial")
         .WithCache(new GuideCache()
@@ -367,5 +386,14 @@ public class TutorialService
         .AddStep(achievementsStr.Step5Title, achievementsStr.Step5Desc, achievementsStr.Step5DescExtended)
         .AddStep(achievementsStr.Step6Title, achievementsStr.Step6Desc, achievementsStr.Step6DescExtended)
         .EnsureSize(TutorialSizes[TutorialType.Achievements]);
+
+        var modPresetsStr = GSLoc.Tutorials.ModPresets;
+        _tutorials[TutorialType.ModPresets] = new Tutorial("Mod Presets")
+            .WithCache(new GuideCache()
+            {
+                BorderColor = ImGui.GetColorU32(ImGuiColors.TankBlue),
+                HighlightColor = ImGui.GetColorU32(ImGuiColors.TankBlue),
+            })
+            .EnsureSize(0);
     }
 }

--- a/ProjectGagSpeak/Services/Tutorial/TutorialSteps.cs
+++ b/ProjectGagSpeak/Services/Tutorial/TutorialSteps.cs
@@ -378,3 +378,8 @@ public enum StepsAchievements
     ProgressDisplay,
     RewardPreview,
 }
+
+public enum StepsModPresets
+{
+    // TODO: NYI
+}

--- a/ProjectGagSpeak/Utils/DalamudWindowExtentions.cs
+++ b/ProjectGagSpeak/Utils/DalamudWindowExtentions.cs
@@ -10,7 +10,7 @@ namespace GagSpeak.Utils;
 /// </summary>
 public class TitleBarButtonBuilder
 {
-    // temporary 
+    // temporary
     private readonly List<TitleBarButton> _buttons = new();
 
     public TitleBarButtonBuilder Add(FAI icon, string tooltip, Action onClick)
@@ -36,6 +36,13 @@ public class TitleBarButtonBuilder
             Click = (msg) =>
             {
                 var type = func.Invoke();
+                if (!service.Exists(type))
+                {
+                    // do nothing, this tutorial doesn't exist just print an error for the devs.
+                    Svc.Logger.Error($"!!!NO TUTORIAL OF {type} ADDED TO DICTIONARY!!!");
+                    return;
+                }
+
                 if (service.IsTutorialActive(type))
                 {
                     service.SkipTutorial(type);
@@ -51,8 +58,14 @@ public class TitleBarButtonBuilder
             ShowTooltip = () =>
             {
                 var type = func.Invoke();
-                CkGui.AttachToolTip(
-                    service.IsTutorialActive(type) ? $"Stop {type} Tutorial" : $"Start {type} tutorial.");
+                if (!service.Exists(type))
+                {
+                    // do nothing, this tutorial doesn't exist just print an error for the devs.
+                    Svc.Logger.Error($"!!!NO TUTORIAL OF {type} ADDED TO DICTIONARY!!!");
+                    return;
+                }
+
+                CkGui.AttachToolTip(service.IsTutorialActive(type) ? $"Stop {type} Tutorial" : $"Start {type} tutorial.");
             },
         });
         return this;
@@ -62,7 +75,7 @@ public class TitleBarButtonBuilder
 }
 
 /// <summary>
-///     Extension methods that help simplify Dalamud window 
+///     Extension methods that help simplify Dalamud window
 ///     setup and operations, to reduce boilerplate code.
 /// </summary>
 public static class DalamudWindowExtentions


### PR DESCRIPTION
Title bar tutorial button could error if a type was assigned but no tutorial was ever added to the tutorial service, causing the title bar colouring to leak to all imgui windows.

This also adds some empty tutorial data for some of the missing tutorials we had buttons for.