### PR TITLE
Dev build title

### DIFF
--- a/ProjectGagSpeak/UI/MainUi/MainUI.cs
+++ b/ProjectGagSpeak/UI/MainUi/MainUI.cs
@@ -78,7 +78,11 @@ public class MainUI : WindowMediatorSubscriberBase
 
         // display info about the folders
         var ver = Assembly.GetExecutingAssembly().GetName().Version!;
+#if !DEBUG
         WindowName = $"GagSpeak v{ver.Major}.{ver.Minor}.{ver.Build}.{ver.Revision}###GagSpeakMainUI";
+#else
+        WindowName = $"GagSpeak v{ver.Major}.{ver.Minor}.{ver.Build}.{ver.Revision} (DEVELOPMENT BUILD)###GagSpeakMainUI";
+#endif
         Flags |= WFlags.NoDocking;
 
         this.PinningClickthroughFalse();


### PR DESCRIPTION
Does what it says, adds `(DEVELOPMENT BUILD)` on the title bar of the main window in debug builds, so it's easier to distinguish if you're running multiple versions.

I am putting this pr up as a suggested change in case we actually want it.