### PR TITLE
Potential fix for padlock fields randomly disabling

### DIFF
--- a/ProjectGagSpeak/CustomCombos/Core/CkPadlockComboBase.cs
+++ b/ProjectGagSpeak/CustomCombos/Core/CkPadlockComboBase.cs
@@ -113,6 +113,7 @@ public abstract class CkPadlockComboBase<T> where T : IPadlockableRestriction
                         SelectedLock = item;
                         _closePopup = true;
                     }
+
                     if (item != 0)
                     {
                         ImGui.SameLine(comboWidth - tooltipIconSize.X);
@@ -121,7 +122,7 @@ public abstract class CkPadlockComboBase<T> where T : IPadlockableRestriction
                     }
                 }
 
-                if(_closePopup)
+                if (_closePopup)
                 {
                     _padlocksList.Clear();
                     _closePopup = false;
@@ -131,7 +132,7 @@ public abstract class CkPadlockComboBase<T> where T : IPadlockableRestriction
 
         // draw button thing for locking / unlocking.
         ImUtf8.SameLineInner();
-        if(buttonTxt.IsNullOrEmpty())
+        if (buttonTxt.IsNullOrEmpty())
         {
             if (CkGui.IconButton(FAI.Lock, disabled: SelectedLock is Padlocks.None, id: "##" + SelectedLock + "-LockButton"))
                 OnLockButtonPress(label, layerIdx);
@@ -141,6 +142,7 @@ public abstract class CkPadlockComboBase<T> where T : IPadlockableRestriction
             if (CkGui.IconTextButton(FAI.Lock, "Lock", disabled: SelectedLock is Padlocks.None, id: "##" + SelectedLock + "-LockButton"))
                 OnLockButtonPress(label, layerIdx);
         }
+
         CkGui.AttachToolTip(tooltip);
 
         // on next line show lock fields.
@@ -184,6 +186,7 @@ public abstract class CkPadlockComboBase<T> where T : IPadlockableRestriction
             if (CkGui.IconTextButton(FAI.Unlock, "Unlock", disabled: lastPadlock is Padlocks.None, id: "##" + label + "-UnlockButton"))
                 OnUnlockButtonPress(label, layerIdx);
         }
+
         CkGui.AttachToolTip(tooltip);
 
         // The special unlock field.
@@ -204,6 +207,7 @@ public abstract class CkPadlockComboBase<T> where T : IPadlockableRestriction
                 CkGui.AttachToolTip($"--COL--{ActiveItem.Timer.ToGsRemainingTimeFancy()}--COL--", color: ImGuiColors.ParsedPink);
                 ImGui.SameLine(0, -ImGui.GetStyle().FramePadding.X);
             }
+
             CkGui.FramedIconText(FAI.Key, ImGui.GetColorU32(ImGuiCol.TextDisabled));
         }
     }

--- a/ProjectGagSpeak/CustomCombos/Core/CkPadlockComboBase.cs
+++ b/ProjectGagSpeak/CustomCombos/Core/CkPadlockComboBase.cs
@@ -1,87 +1,84 @@
-using CkCommons;
 using CkCommons.Gui;
+using Dalamud.Bindings.ImGui;
 using Dalamud.Interface.Colors;
 using GagspeakAPI.Data;
 using GagspeakAPI.Extensions;
-using Dalamud.Bindings.ImGui;
-using OtterGui.Classes;
 using OtterGui.Raii;
 using OtterGui.Text;
 
 namespace GagSpeak.CustomCombos;
 
 // The true core of the abstract combos for padlocks. Handles all shared logic operations.
-// 
+//
 // Maintainers Note:
 // - The PadlockBase Draw() call handles the passing in of the layer it works with. This layer can be defaulted to -1 if unused.
 // - The layer is used so that when Lock() and Unlock() operations are used, their respective parent object knows what layer called it.
 // This prevents us from needing to store multiple caches of the same padlock, and redundant code blocks.
-// - (?) Is is the parent classes responsibility to ensure whenever padlock combo changes layers, its selections are reset and cleared.
+// - (?) It is the parent classes responsibility to ensure whenever padlock combo changes layers, its selections are reset and cleared.
 public abstract class CkPadlockComboBase<T> where T : IPadlockableRestriction
 {
     protected readonly ILogger Log;
 
-    public readonly ICachingList<T> Items;
-
-    /// <summary> Contains the list of padlocks. </summary>
-    public readonly ICachingList<Padlocks> ComboPadlocks;
-    protected float? InnerWidth;
-    protected int? NewSelection;
+    protected T ActiveItem;
     protected string Password = string.Empty;
     protected string Timer = string.Empty;
+    protected Padlocks SelectedLock { get; set; } = Padlocks.None;
+
+    private readonly Func<List<Padlocks>> _padlocksListGenerator;
+    private List<Padlocks> _padlocksList;
     private bool _closePopup;
 
-    public Padlocks SelectedLock { get; protected set; } = Padlocks.None;
-    protected CkPadlockComboBase(IEnumerable<T> items, IEnumerable<Padlocks> padlocks, ILogger log)
+    protected CkPadlockComboBase(Func<List<Padlocks>> padlocks, ILogger log)
     {
         Log = log;
-        Items = (ICachingList<T>)new TemporaryList<T>(items);
-        ComboPadlocks = new TemporaryList<Padlocks>(padlocks);
+        _padlocksListGenerator = padlocks;
+        _padlocksList = padlocks();
     }
 
-    protected CkPadlockComboBase(Func<IReadOnlyList<T>> itemGen, IEnumerable<Padlocks> padlocks, ILogger log)
+    /// <summary>
+    /// Clears the list of stored locks, changes the selected padlock to none, and resets the text input fields.
+    /// </summary>
+    protected void ResetSelection()
     {
-        Log = log;
-        Items = (ICachingList<T>)(new LazyList<T>(itemGen));
-        ComboPadlocks = new TemporaryList<Padlocks>(padlocks);
-    }
-
-    protected CkPadlockComboBase(Func<IReadOnlyList<T>> itemGen, Func<IReadOnlyList<Padlocks>> padlockGen, ILogger log)
-    {
-        Log = log;
-        Items = new LazyList<T>(itemGen);
-        ComboPadlocks = new LazyList<Padlocks>(padlockGen);
-    }
-
-    public void ResetSelection()
-    {
-        ComboPadlocks.ClearList();
+        _padlocksList.Clear();
+        SelectedLock = Padlocks.None;
         ResetInputs();
     }
 
-    protected void RefreshStorage(string label)
-    {
-        Log.LogTrace($"Clearing storage for padlock combo: {label}", LoggerType.Combos);
-        Items.ClearList();
-    }
+    /// <summary>
+    /// Resets text input fields.
+    /// </summary>
+    protected void ResetInputs() => (Password, Timer) = (string.Empty, string.Empty);
 
-    public void ResetInputs() => (Password, Timer) = (string.Empty, string.Empty);
-
+    /// <summary>
+    /// The conditions under which a lock or unlock group needs to be disabled.
+    /// </summary>
+    /// <param name="layerIdx">the layer to affect</param>
+    /// <returns><see langword="true"/> if the row should be disabled.</returns>
     protected abstract bool DisableCondition(int layerIdx);
 
     protected virtual string ItemName(T item) => item.ToString() ?? string.Empty;
 
     /// <summary> The logic that occurs when the lock button is pressed. </summary>
     /// <returns> If the operation was successful or not. </returns>
-    protected abstract Task<bool> OnLockButtonPress(string label, int layerIdx);
+    protected abstract Task OnLockButtonPress(string label, int layerIdx);
 
     /// <summary> The logic that occurs when the unlock button is pressed. </summary>
     /// <returns> If the operation was successful or not. </returns>
-    protected abstract Task<bool> OnUnlockButtonPress(string label, int layerIdx);
+    protected abstract Task OnUnlockButtonPress(string label, int layerIdx);
 
+    /// <summary>
+    /// Handles drawing the Item Lock inputs. <see cref="ActiveItem"/> must be set in the overriding method.
+    /// </summary>
+    /// <param name="label">Internal label for this item</param>
+    /// <param name="width">Total available width, px.</param>
+    /// <param name="layerIdx">The layer index of the affecting item</param>
+    /// <param name="buttonTxt">The text to display on the Lock button</param>
+    /// <param name="tooltip">The tooltip to display on the Lock button.</param>
+    /// <param name="isTwoRow">If the Item Lock inputs should be drawn on two or three rows.</param>
     public virtual void DrawLockCombo(string label, float width, int layerIdx, string buttonTxt, string tooltip, bool isTwoRow)
     {
-        // we need to calculate the size of the button for locking, so do so.
+        // we need to calculate the size of the button for locking
         using var group = ImRaii.Group();
         var buttonWidth = buttonTxt.IsNullOrEmpty()
             ? CkGui.IconButtonSize(FAI.Lock).X
@@ -95,7 +92,6 @@ public abstract class CkPadlockComboBase<T> where T : IPadlockableRestriction
         using var disabled = ImRaii.Disabled(DisableCondition(layerIdx));
         using (var combo = ImRaii.Combo(label, SelectedLock.ToName()))
         {
-            // display the tooltip for the combo with visible.
             using (ImRaii.Enabled())
             {
                 if (ImGui.IsItemClicked(ImGuiMouseButton.Right))
@@ -105,7 +101,12 @@ public abstract class CkPadlockComboBase<T> where T : IPadlockableRestriction
             // handle combo.
             if (combo)
             {
-                foreach (var item in ComboPadlocks)
+                if (_padlocksList.Count == 0)
+                {
+                    _padlocksList = _padlocksListGenerator();
+                }
+
+                foreach (var item in _padlocksList)
                 {
                     if (ImGui.Selectable(item.ToName(), item == SelectedLock))
                     {
@@ -122,7 +123,7 @@ public abstract class CkPadlockComboBase<T> where T : IPadlockableRestriction
 
                 if(_closePopup)
                 {
-                    RefreshStorage(label);
+                    _padlocksList.Clear();
                     _closePopup = false;
                 }
             }
@@ -151,13 +152,13 @@ public abstract class CkPadlockComboBase<T> where T : IPadlockableRestriction
 
     public virtual void DrawUnlockCombo(string label, float width, int layerIdx, string buttonTxt, string tooltip)
     {
-        // we need to calculate the size of the button for locking, so do so.
+        // we need to calculate the size of the button for locking
         using var group = ImRaii.Group();
         var buttonWidth = buttonTxt.IsNullOrEmpty()
             ? CkGui.IconButtonSize(FAI.Unlock).X
             : CkGui.IconTextButtonSize(FAI.Unlock, "Unlock");
         var unlockWidth = width - buttonWidth - ImGui.GetStyle().ItemInnerSpacing.X;
-        var lastPadlock = Items[layerIdx].Padlock;
+        var lastPadlock = ActiveItem.Padlock;
         // display the active padlock for the set in a disabled view.
         using (ImRaii.Group())
         {
@@ -173,7 +174,7 @@ public abstract class CkPadlockComboBase<T> where T : IPadlockableRestriction
 
         // draw button thing.
         ImUtf8.SameLineInner();
-        if (buttonTxt.IsNullOrEmpty())    
+        if (buttonTxt.IsNullOrEmpty())
         {
             if (CkGui.IconButton(FAI.Unlock, disabled: lastPadlock is Padlocks.None, id: "##" + label + "-UnlockButton"))
                 OnUnlockButtonPress(label, layerIdx);
@@ -184,7 +185,7 @@ public abstract class CkPadlockComboBase<T> where T : IPadlockableRestriction
                 OnUnlockButtonPress(label, layerIdx);
         }
         CkGui.AttachToolTip(tooltip);
-        
+
         // The special unlock field.
         void DrawUnlockFieldSpecial(float width, string hint, bool isTimer)
         {
@@ -200,7 +201,7 @@ public abstract class CkPadlockComboBase<T> where T : IPadlockableRestriction
             if (isTimer)
             {
                 CkGui.AnimatedHourglass(3000);
-                CkGui.AttachToolTip($"--COL--{Items[layerIdx].Timer.ToGsRemainingTimeFancy()}--COL--", color: ImGuiColors.ParsedPink);
+                CkGui.AttachToolTip($"--COL--{ActiveItem.Timer.ToGsRemainingTimeFancy()}--COL--", color: ImGuiColors.ParsedPink);
                 ImGui.SameLine(0, -ImGui.GetStyle().FramePadding.X);
             }
             CkGui.FramedIconText(FAI.Key, ImGui.GetColorU32(ImGuiCol.TextDisabled));
@@ -209,14 +210,13 @@ public abstract class CkPadlockComboBase<T> where T : IPadlockableRestriction
 
     /// <summary> Draws out the padlock fields below. </summary>
     /// <remarks> IsTwoRow defines if it is made for restrictions/restraints or gags. </remarks>
-    protected void TwoRowLockFields(string id, float width)
+    private void TwoRowLockFields(string id, float width)
     {
         var leftWidth = width * .6f;
         var rightWidth = width - leftWidth - ImGui.GetStyle().ItemInnerSpacing.X;
 
-        var passLabel = "##Input_" + id;
-        var passHint = SelectedLock == Padlocks.Combination ? "Set 4 digit combo.." : "Guess password..";
-        var timerHint = "Ex: 0h2m7s";
+        var passHint = SelectedLock == Padlocks.Combination ? "Set 4 digit combo.." : "Set password..";
+        const string timerHint = "Ex: 0h2m7s";
         var maxLength = SelectedLock == Padlocks.Combination ? 4 : 20;
         var flags = SelectedLock == Padlocks.Combination ? ITFlags.CharsDecimal : ITFlags.None;
 
@@ -231,10 +231,10 @@ public abstract class CkPadlockComboBase<T> where T : IPadlockableRestriction
             "--SEP--Ex: 0h2m7s (0 hours, 2 minutes, 7 seconds).");
     }
 
-    protected void ThreeRowLockFields(string id, float width)
+    private void ThreeRowLockFields(string id, float width)
     {
-        var passHint = SelectedLock == Padlocks.Combination ? "Set 4 digit combo.." : "Guess password..";
-        var timerHint = "Ex: 0h2m7s";
+        var passHint = SelectedLock == Padlocks.Combination ? "Set 4 digit combo.." : "Set password..";
+        const string timerHint = "Ex: 0h2m7s";
         var maxLength = SelectedLock == Padlocks.Combination ? 4 : 20;
         var flags = SelectedLock == Padlocks.Combination ? ITFlags.CharsDecimal : ITFlags.None;
 

--- a/ProjectGagSpeak/CustomCombos/Core/CkPadlockComboBase.cs
+++ b/ProjectGagSpeak/CustomCombos/Core/CkPadlockComboBase.cs
@@ -3,6 +3,7 @@ using Dalamud.Bindings.ImGui;
 using Dalamud.Interface.Colors;
 using GagspeakAPI.Data;
 using GagspeakAPI.Extensions;
+using OtterGui.Classes;
 using OtterGui.Raii;
 using OtterGui.Text;
 
@@ -24,15 +25,15 @@ public abstract class CkPadlockComboBase<T> where T : IPadlockableRestriction
     protected string Timer = string.Empty;
     protected Padlocks SelectedLock { get; set; } = Padlocks.None;
 
-    private readonly Func<List<Padlocks>> _padlocksListGenerator;
-    private List<Padlocks> _padlocksList;
+    private readonly ICachingList<Padlocks> _padlocksList;
+    //private readonly Func<List<Padlocks>> _padlocksListGenerator;
+    //private List<Padlocks> _padlocksList;
     private bool _closePopup;
 
-    protected CkPadlockComboBase(Func<List<Padlocks>> padlocks, ILogger log)
+    protected CkPadlockComboBase(Func<IReadOnlyList<Padlocks>> padlocks, ILogger log)
     {
         Log = log;
-        _padlocksListGenerator = padlocks;
-        _padlocksList = padlocks();
+        _padlocksList = new LazyList<Padlocks>(padlocks);
     }
 
     /// <summary>
@@ -40,7 +41,7 @@ public abstract class CkPadlockComboBase<T> where T : IPadlockableRestriction
     /// </summary>
     protected void ResetSelection()
     {
-        _padlocksList.Clear();
+        _padlocksList.ClearList();
         SelectedLock = Padlocks.None;
         ResetInputs();
     }
@@ -101,11 +102,6 @@ public abstract class CkPadlockComboBase<T> where T : IPadlockableRestriction
             // handle combo.
             if (combo)
             {
-                if (_padlocksList.Count == 0)
-                {
-                    _padlocksList = _padlocksListGenerator();
-                }
-
                 foreach (var item in _padlocksList)
                 {
                     if (ImGui.Selectable(item.ToName(), item == SelectedLock))
@@ -124,7 +120,7 @@ public abstract class CkPadlockComboBase<T> where T : IPadlockableRestriction
 
                 if (_closePopup)
                 {
-                    _padlocksList.Clear();
+                    _padlocksList.ClearList();
                     _closePopup = false;
                 }
             }

--- a/ProjectGagSpeak/CustomCombos/Padlocks/PadlockGagsClient.cs
+++ b/ProjectGagSpeak/CustomCombos/Padlocks/PadlockGagsClient.cs
@@ -1,12 +1,9 @@
 using GagSpeak.Services;
-using GagSpeak.State.Listeners;
 using GagSpeak.State.Managers;
-using GagSpeak.Utils;
 using GagSpeak.WebAPI;
 using GagspeakAPI.Data;
 using GagspeakAPI.Extensions;
 using GagspeakAPI.Util;
-using OtterGui.Classes;
 
 namespace GagSpeak.CustomCombos.Padlock;
 
@@ -14,76 +11,80 @@ namespace GagSpeak.CustomCombos.Padlock;
 public class PadlockGagsClient : CkPadlockComboBase<ActiveGagSlot>
 {
     private readonly SelfBondageService _selfBondage;
+    private readonly GagRestrictionManager _manager;
+
     public PadlockGagsClient(ILogger log, GagRestrictionManager manager, SelfBondageService selfBondage)
-        : base(new LazyList<ActiveGagSlot>(() => [ ..manager.ServerGagData?.GagSlots ?? [new ActiveGagSlot()] ]), PadlockEx.ClientLocks, log)
+        : base(() => [..PadlockEx.ClientLocks], log)
     {
         _selfBondage = selfBondage;
+        _manager = manager;
     }
 
     protected override string ItemName(ActiveGagSlot item)
         => item.GagItem.GagName();
 
     protected override bool DisableCondition(int layerIdx)
-        => Items[layerIdx].GagItem is GagType.None;
+        => ActiveItem.GagItem is GagType.None;
 
     public void DrawLockCombo(float width, int layerIdx, string tooltip)
-        => DrawLockCombo($"##ClientGagLock-{layerIdx}", width, layerIdx, string.Empty, tooltip, false);
+    {
+        ActiveItem = _manager.ServerGagData?.GagSlots[layerIdx] ?? new ActiveGagSlot();
+        DrawLockCombo($"##ClientGagLock-{layerIdx}", width, layerIdx, string.Empty, tooltip, false);
+    }
 
     public void DrawUnlockCombo(float width, int layerIdx, string tooltip)
-        => DrawUnlockCombo($"##ClientGagUnlock-{layerIdx}", width, layerIdx, string.Empty, tooltip);
-
-    protected override async Task<bool> OnLockButtonPress(string label, int layerIdx)
     {
-        if (!Items[layerIdx].CanLock())
-            return false;
+        ActiveItem = _manager.ServerGagData?.GagSlots[layerIdx] ?? new ActiveGagSlot();
+        DrawUnlockCombo($"##ClientGagUnlock-{layerIdx}", width, layerIdx, string.Empty, tooltip);
+    }
 
-        if (!ValidateLock(layerIdx))
-            return false;
+    protected override async Task OnLockButtonPress(string label, int layerIdx)
+    {
+        if (!ActiveItem.CanLock())
+            return;
+
+        if (!ValidateLock())
+            return;
 
         // we know it was valid, so begin assigning the new data to send off.
         var time = SelectedLock is Padlocks.FiveMinutes ? DateTimeOffset.UtcNow.Add(TimeSpan.FromMinutes(5)) : Timer.GetEndTimeUTC();
-        var newData = Items[layerIdx] with { Padlock = SelectedLock, Password = Password, Timer = time, PadlockAssigner = MainHub.UID };
+        var newData = ActiveItem with { Padlock = SelectedLock, Password = Password, Timer = time, PadlockAssigner = MainHub.UID };
         if (await _selfBondage.DoSelfGagResult(layerIdx, newData, DataUpdateType.Locked))
         {
-            ResetSelection();
-            ResetInputs();
-            RefreshStorage(label);
-            return true;
+            ActiveItem = new ActiveGagSlot();
         }
         else
         {
-            ResetSelection();
-            ResetInputs();
-            return false;
+            Log.LogDebug($"Failed to perform LockGag with {SelectedLock.ToName()} on self.", LoggerType.StickyUI);
         }
+        ResetSelection();
+        ResetInputs();
     }
 
-    protected override async Task<bool> OnUnlockButtonPress(string label, int layerIdx)
+    protected override async Task OnUnlockButtonPress(string label, int layerIdx)
     {
-        if (!Items[layerIdx].CanUnlock())
-            return false;
+        if (!ActiveItem.CanUnlock())
+            return;
 
-        if(!ValidateUnlock(layerIdx))
-            return false;
+        if (!ValidateUnlock())
+            return;
 
-        var newData = Items[layerIdx] with { Padlock = Items[layerIdx].Padlock, Password = Items[layerIdx].Password, PadlockAssigner = MainHub.UID };
-        if (await _selfBondage.DoSelfGagResult(layerIdx, newData, DataUpdateType.Unlocked))
+        //the server never uses this data, so why are we setting it?
+        //var newData = ActiveItem with { Padlock = ActiveItem.Padlock, Password = ActiveItem.Password, PadlockAssigner = MainHub.UID };
+        if (await _selfBondage.DoSelfGagResult(layerIdx, ActiveItem, DataUpdateType.Unlocked))
         {
-            ResetSelection();
-            ResetInputs();
-            RefreshStorage(label);
+            ActiveItem = new ActiveGagSlot();
             SelectedLock = Padlocks.None;
-            return true;
         }
         else
         {
-            ResetSelection();
-            ResetInputs();
-            return false;
+            Log.LogDebug("Failed to perform UnlockGag on self.");
         }
+        ResetSelection();
+        ResetInputs();
     }
 
-    private bool ValidateLock(int layerIdx)
+    private bool ValidateLock()
     {
         // Determine if we have access to unlock.
         var valid = SelectedLock switch
@@ -127,15 +128,15 @@ public class PadlockGagsClient : CkPadlockComboBase<ActiveGagSlot>
         return false;
     }
 
-    private bool ValidateUnlock(int layerIdx)
+    private bool ValidateUnlock()
     {
         // Determine if we have access to unlock.
-        var valid = Items[layerIdx].Padlock switch
+        var valid = ActiveItem.Padlock switch
         {
             Padlocks.Metal or Padlocks.FiveMinutes or Padlocks.Timer => true,
-            Padlocks.Combination => Items[layerIdx].Password == Password,
-            Padlocks.Password => Items[layerIdx].Password == Password,
-            Padlocks.TimerPassword => Items[layerIdx].Password == Password,
+            Padlocks.Combination => ActiveItem.Password == Password,
+            Padlocks.Password => ActiveItem.Password == Password,
+            Padlocks.TimerPassword => ActiveItem.Password == Password,
             _ => false
         };
 

--- a/ProjectGagSpeak/CustomCombos/Padlocks/PadlockGagsPair.cs
+++ b/ProjectGagSpeak/CustomCombos/Padlocks/PadlockGagsPair.cs
@@ -12,9 +12,9 @@ public class PairGagPadlockCombo : CkPadlockComboBase<ActiveGagSlot>
 {
     private Action PostButtonPress;
     private readonly MainHub _mainHub;
-    private Kinkster _ref;
+    private readonly Kinkster _ref;
     public PairGagPadlockCombo(ILogger log, MainHub hub, Kinkster k, Action postButtonPress)
-        : base(() => [ .. k.ActiveGags.GagSlots ], () => [ ..PadlockEx.GetLocksForPair(k.PairPerms) ], log)
+        : base(() => [..PadlockEx.GetLocksForPair(k.PairPerms)], log)
     {
         _mainHub = hub;
         _ref = k;
@@ -23,15 +23,27 @@ public class PairGagPadlockCombo : CkPadlockComboBase<ActiveGagSlot>
 
     protected override string ItemName(ActiveGagSlot item)
         => item.GagItem.GagName();
-    
-    protected override bool DisableCondition(int layerIdx)
-        => Items[layerIdx].GagItem is GagType.None;
 
-    protected override async Task<bool> OnLockButtonPress(string label, int layerIdx)
+    protected override bool DisableCondition(int layerIdx)
+        => ActiveItem.GagItem is GagType.None;
+
+    public override void DrawLockCombo(string label, float width, int layerIdx, string buttonTxt, string tooltip, bool isTwoRow)
+    {
+        ActiveItem = _ref.ActiveGags.GagSlots[layerIdx];
+        base.DrawLockCombo(label, width, layerIdx, buttonTxt, tooltip, isTwoRow);
+    }
+
+    public override void DrawUnlockCombo(string label, float width, int layerIdx, string buttonTxt, string tooltip)
+    {
+        ActiveItem = _ref.ActiveGags.GagSlots[layerIdx];
+        base.DrawUnlockCombo(label, width, layerIdx, buttonTxt, tooltip);
+    }
+
+    protected override async Task OnLockButtonPress(string label, int layerIdx)
     {
         // return if we cannot lock.
-        if (!Items[layerIdx].CanLock() || !_ref.PairPerms.LockGags)
-            return false;
+        if (!ActiveItem.CanLock() || !_ref.PairPerms.LockGags)
+            return;
 
         // we know it was valid, so begin assigning the new data to send off.
         var finalTime = SelectedLock == Padlocks.FiveMinutes
@@ -52,32 +64,28 @@ public class PairGagPadlockCombo : CkPadlockComboBase<ActiveGagSlot>
         {
             Log.LogDebug($"Failed to perform LockGag with {SelectedLock.ToName()} on {_ref.GetNickAliasOrUid()}, Reason:{result}", LoggerType.StickyUI);
             DisplayToastErrorAndReset(result.ErrorCode, SelectedLock, false);
-            return false;
+            return;
         }
-        else
-        {
-            Log.LogDebug($"Locking Gag with {SelectedLock.ToName()} on {_ref.GetNickAliasOrUid()}", LoggerType.StickyUI);
-            ResetSelection();
-            ResetInputs();
-            RefreshStorage(label);
-            PostButtonPress?.Invoke();
-            return true;
-        }
+        Log.LogDebug($"Locking Gag with {SelectedLock.ToName()} on {_ref.GetNickAliasOrUid()}", LoggerType.StickyUI);
+        ResetSelection();
+        ResetInputs();
+        ActiveItem = new ActiveGagSlot();
+        PostButtonPress?.Invoke();
     }
 
-    protected override async Task<bool> OnUnlockButtonPress(string label, int layerIdx)
+    protected override async Task OnUnlockButtonPress(string label, int layerIdx)
     {
         // return if we cannot lock.
-        if (!Items[layerIdx].CanUnlock() || !_ref.PairPerms.UnlockGags)
+        if (!ActiveItem.CanUnlock() || !_ref.PairPerms.UnlockGags)
         {
-            Log.LogDebug($"Cannot unlock Gag with {Items[layerIdx].Padlock.ToName()} on {_ref.GetNickAliasOrUid()}, Reason: Cannot Unlock", LoggerType.StickyUI);
-            return false;
+            Log.LogDebug($"Cannot unlock Gag with {ActiveItem.Padlock.ToName()} on {_ref.GetNickAliasOrUid()}, Reason: Cannot Unlock", LoggerType.StickyUI);
+            return;
         }
 
         var dto = new PushKinksterActiveGagSlot(_ref.UserData, DataUpdateType.Unlocked)
         {
             Layer = layerIdx,
-            Padlock = Items[layerIdx].Padlock,
+            Padlock = ActiveItem.Padlock,
             Password = Password, // Our guessed password.
             PadlockAssigner = MainHub.UID,
         };
@@ -85,20 +93,17 @@ public class PairGagPadlockCombo : CkPadlockComboBase<ActiveGagSlot>
         var result = await _mainHub.UserChangeKinksterActiveGag(dto);
         if (result.ErrorCode is not GagSpeakApiEc.Success)
         {
-            Log.LogDebug($"Failed to perform UnlockGag with {Items[layerIdx].Padlock.ToName()} on {_ref.GetNickAliasOrUid()}, Reason:{result}", LoggerType.StickyUI);
-            DisplayToastErrorAndReset(result.ErrorCode, Items[layerIdx].Padlock, true);
-            return false;
+            Log.LogDebug($"Failed to perform UnlockGag with {ActiveItem.Padlock.ToName()} on {_ref.GetNickAliasOrUid()}, Reason:{result}", LoggerType.StickyUI);
+            DisplayToastErrorAndReset(result.ErrorCode, ActiveItem.Padlock, true);
+            return;
         }
-        else
-        {
-            Log.LogDebug($"Unlocking Gag with {Items[layerIdx].Padlock.ToName()} on {_ref.GetNickAliasOrUid()}", LoggerType.StickyUI);
-            ResetSelection();
-            ResetInputs();
-            RefreshStorage(label);
-            SelectedLock = Padlocks.None;
-            PostButtonPress?.Invoke();
-            return true;
-        }
+
+        Log.LogDebug($"Unlocking Gag with {ActiveItem.Padlock.ToName()} on {_ref.GetNickAliasOrUid()}", LoggerType.StickyUI);
+        ResetSelection();
+        ResetInputs();
+        ActiveItem = new ActiveGagSlot();
+        SelectedLock = Padlocks.None;
+        PostButtonPress?.Invoke();
     }
 
     private bool DisplayToastErrorAndReset(GagSpeakApiEc errorCode, Padlocks padlock, bool unlocking)

--- a/ProjectGagSpeak/CustomCombos/Padlocks/PadlockRestraintsClient.cs
+++ b/ProjectGagSpeak/CustomCombos/Padlocks/PadlockRestraintsClient.cs
@@ -1,7 +1,5 @@
 using GagSpeak.Services;
-using GagSpeak.State.Listeners;
 using GagSpeak.State.Managers;
-using GagSpeak.Utils;
 using GagSpeak.WebAPI;
 using GagspeakAPI.Data;
 using GagspeakAPI.Extensions;
@@ -12,8 +10,9 @@ public class PadlockRestraintsClient : CkPadlockComboBase<CharaActiveRestraint>
 {
     private readonly RestraintManager _manager;
     private readonly SelfBondageService _selfBondage;
+
     public PadlockRestraintsClient(ILogger log, RestraintManager manager, SelfBondageService selfBondage)
-        : base(() => [ manager.ServerData ?? new CharaActiveRestraint() ], PadlockEx.ClientLocks, log)
+        : base(() => [..PadlockEx.ClientLocks], log)
     {
         _manager = manager;
         _selfBondage = selfBondage;
@@ -23,60 +22,63 @@ public class PadlockRestraintsClient : CkPadlockComboBase<CharaActiveRestraint>
         => _manager.Storage.TryGetRestraint(item.Identifier, out var restraint) ? restraint.Label : "None";
 
     protected override bool DisableCondition(int _)
-        => Items[0].Identifier == Guid.Empty;
+        => ActiveItem.Identifier == Guid.Empty;
 
     public void DrawLockCombo(float width, string tooltip)
-        => DrawLockCombo("##ClientRestraintLock", width, 0, string.Empty, tooltip, true);
+    {
+        ActiveItem = _manager.ServerData ?? new CharaActiveRestraint();
+        DrawLockCombo("##ClientRestraintLock", width, 0, string.Empty, tooltip, true);
+    }
 
     public void DrawUnlockCombo(float width, string tooltip)
-        => DrawUnlockCombo("##ClientRestraintUnlock", width, 0, string.Empty, tooltip);
-
-    protected override async Task<bool> OnLockButtonPress(string label, int _)
     {
-        if (!Items[0].CanLock())
-            return false;
+        ActiveItem = _manager.ServerData ?? new CharaActiveRestraint();
+        DrawUnlockCombo("##ClientRestraintUnlock", width, 0, string.Empty, tooltip);
+    }
+
+    protected override async Task OnLockButtonPress(string label, int _)
+    {
+        if (!ActiveItem.CanLock())
+            return;
 
         if (!ValidateLock())
-            return false;
+            return;
 
         // get new data.
         var time = SelectedLock is Padlocks.FiveMinutes ? DateTimeOffset.UtcNow.Add(TimeSpan.FromMinutes(5)) : Timer.GetEndTimeUTC();
         var newData = new CharaActiveRestraint() { Padlock = SelectedLock, Password = Password, Timer = time, PadlockAssigner = MainHub.UID };
         if (await _selfBondage.DoSelfRestraintResult(newData, DataUpdateType.Locked))
         {
-            ResetSelection();
-            ResetInputs();
-            RefreshStorage(label);
-            return true;
-        }
-        Log.LogDebug($"Failed to perform LockRestraint with {SelectedLock.ToName()} on self", LoggerType.StickyUI);
-        ResetSelection();
-        ResetInputs();
-        return false;
-    }
-    protected override async Task<bool> OnUnlockButtonPress(string label, int _)
-    {
-        if (!Items[0].CanUnlock())
-            return false;
-
-        if (!ValidateUnlock())
-            return false;
-
-        var newData = Items[0] with { Padlock = Items[0].Padlock, Password = Items[0].Password, PadlockAssigner = MainHub.UID };
-        if (await _selfBondage.DoSelfRestraintResult(newData, DataUpdateType.Unlocked))
-        {
-            ResetSelection();
-            ResetInputs();
-            RefreshStorage(label);
-            SelectedLock = Padlocks.None;
-            return true;
+            ActiveItem = new CharaActiveRestraint();
         }
         else
         {
-            ResetSelection();
-            ResetInputs();
-            return false;
+            Log.LogDebug($"Failed to perform LockRestraint with {SelectedLock.ToName()} on self.", LoggerType.StickyUI);
         }
+        ResetSelection();
+        ResetInputs();
+    }
+
+    protected override async Task OnUnlockButtonPress(string label, int _)
+    {
+        if (!ActiveItem.CanUnlock())
+            return;
+
+        if (!ValidateUnlock())
+            return;
+
+        var newData = ActiveItem with { Padlock = ActiveItem.Padlock, Password = ActiveItem.Password, PadlockAssigner = MainHub.UID };
+        if (await _selfBondage.DoSelfRestraintResult(newData, DataUpdateType.Unlocked))
+        {
+            ActiveItem = new CharaActiveRestraint();
+            SelectedLock = Padlocks.None;
+        }
+        else
+        {
+            Log.LogDebug("Failed to perform UnlockRestraint on self.");
+        }
+        ResetSelection();
+        ResetInputs();
     }
 
     private bool ValidateLock()
@@ -126,12 +128,12 @@ public class PadlockRestraintsClient : CkPadlockComboBase<CharaActiveRestraint>
     private bool ValidateUnlock()
     {
         // Determine if we have access to unlock.
-        var valid = Items[0].Padlock switch
+        var valid = ActiveItem.Padlock switch
         {
             Padlocks.Metal or Padlocks.FiveMinutes or Padlocks.Timer => true,
-            Padlocks.Combination => Items[0].Password == Password,
-            Padlocks.Password => Items[0].Password == Password,
-            Padlocks.TimerPassword => Items[0].Password == Password,
+            Padlocks.Combination => ActiveItem.Password == Password,
+            Padlocks.Password => ActiveItem.Password == Password,
+            Padlocks.TimerPassword => ActiveItem.Password == Password,
             _ => false
         };
 

--- a/ProjectGagSpeak/CustomCombos/Padlocks/PadlockRestraintsPair.cs
+++ b/ProjectGagSpeak/CustomCombos/Padlocks/PadlockRestraintsPair.cs
@@ -13,8 +13,9 @@ public class PairRestraintPadlockCombo : CkPadlockComboBase<CharaActiveRestraint
     private Action PostButtonPress;
     private readonly MainHub _mainHub;
     private Kinkster _ref;
+
     public PairRestraintPadlockCombo(ILogger log, MainHub hub, Kinkster k, Action postButtonPress)
-        : base(() => [k.ActiveRestraint], () => [..PadlockEx.GetLocksForPair(k.PairPerms)], log)
+        : base(() => [..PadlockEx.GetLocksForPair(k.PairPerms)], log)
     {
         _mainHub = hub;
         _ref = k;
@@ -23,18 +24,32 @@ public class PairRestraintPadlockCombo : CkPadlockComboBase<CharaActiveRestraint
 
     protected override string ItemName(CharaActiveRestraint item)
         => _ref.LightCache.Restraints.TryGetValue(item.Identifier, out var restraint) ? restraint.Label : "None";
-    protected override bool DisableCondition(int _)
-        => Items[0].Identifier == Guid.Empty;
 
-    protected override async Task<bool> OnLockButtonPress(string label, int _)
+    protected override bool DisableCondition(int _)
+        => ActiveItem.Identifier == Guid.Empty;
+
+    public override void DrawLockCombo(string label, float width, int layerIdx, string buttonTxt, string tooltip, bool isTwoRow)
+    {
+        ActiveItem = _ref.ActiveRestraint;
+        base.DrawLockCombo(label, width, layerIdx, buttonTxt, tooltip, isTwoRow);
+    }
+
+    public override void DrawUnlockCombo(string label, float width, int layerIdx, string buttonTxt, string tooltip)
+    {
+        ActiveItem = _ref.ActiveRestraint;
+        base.DrawUnlockCombo(label, width, layerIdx, buttonTxt, tooltip);
+    }
+
+    protected override async Task OnLockButtonPress(string label, int _)
     {
         // return if we cannot lock.
-        if (!Items[0].CanLock() || !_ref.PairPerms.LockRestraintSets)
-            return false;
+        if (!ActiveItem.CanLock() || !_ref.PairPerms.LockRestraintSets)
+            return;
 
         // we know it was valid, so begin assigning the new data to send off.
         var finalTime = SelectedLock == Padlocks.FiveMinutes
-            ? DateTimeOffset.UtcNow.Add(TimeSpan.FromMinutes(5)) : Timer.GetEndTimeUTC();
+            ? DateTimeOffset.UtcNow.Add(TimeSpan.FromMinutes(5))
+            : Timer.GetEndTimeUTC();
 
         var dto = new PushKinksterActiveRestraint(_ref.UserData, DataUpdateType.Locked)
         {
@@ -49,27 +64,24 @@ public class PairRestraintPadlockCombo : CkPadlockComboBase<CharaActiveRestraint
         {
             Log.LogDebug($"Failed to perform LockRestraint with {SelectedLock.ToName()} on {_ref.GetNickAliasOrUid()}, Reason:{LoggerType.StickyUI}");
             DisplayToastErrorAndReset(result.ErrorCode, SelectedLock, false);
-            return false;
+            return;
         }
-        else
-        {
-            Log.LogDebug($"Locking Restraint with {SelectedLock.ToName()} on {_ref.GetNickAliasOrUid()}", LoggerType.StickyUI);
-            ResetSelection();
-            ResetInputs();
-            RefreshStorage(label);
-            PostButtonPress.Invoke();
-            return true;
-        }
+
+        Log.LogDebug($"Locking Restraint with {SelectedLock.ToName()} on {_ref.GetNickAliasOrUid()}", LoggerType.StickyUI);
+        ResetSelection();
+        ResetInputs();
+        ActiveItem = new CharaActiveRestraint();
+        PostButtonPress.Invoke();
     }
 
-    protected override async Task<bool> OnUnlockButtonPress(string label, int _)
+    protected override async Task OnUnlockButtonPress(string label, int _)
     {
-        if (!Items[0].CanUnlock() || !_ref.PairPerms.UnlockRestraintSets)
-            return false;
+        if (!ActiveItem.CanUnlock() || !_ref.PairPerms.UnlockRestraintSets)
+            return;
 
         var dto = new PushKinksterActiveRestraint(_ref.UserData, DataUpdateType.Unlocked)
         {
-            Padlock = Items[0].Padlock,
+            Padlock = ActiveItem.Padlock,
             Password = Password,
             PadlockAssigner = MainHub.UID,
         };
@@ -80,19 +92,16 @@ public class PairRestraintPadlockCombo : CkPadlockComboBase<CharaActiveRestraint
         if (result.ErrorCode is not GagSpeakApiEc.Success)
         {
             Log.LogDebug($"Failed to perform UnlockRestraint with {SelectedLock.ToName()} on {_ref.GetNickAliasOrUid()}, Reason:{LoggerType.StickyUI}");
-            DisplayToastErrorAndReset(result.ErrorCode, Items[0].Padlock, true);
-            return false;
+            DisplayToastErrorAndReset(result.ErrorCode, ActiveItem.Padlock, true);
+            return;
         }
-        else
-        {
-            Log.LogDebug($"Unlocking Restraint with {SelectedLock.ToName()} on {_ref.GetNickAliasOrUid()}", LoggerType.StickyUI);
-            ResetSelection();
-            ResetInputs();
-            RefreshStorage(label);
-            SelectedLock = Padlocks.None;
-            PostButtonPress.Invoke();
-            return true;
-        }
+
+        Log.LogDebug($"Unlocking Restraint with {SelectedLock.ToName()} on {_ref.GetNickAliasOrUid()}", LoggerType.StickyUI);
+        ResetSelection();
+        ResetInputs();
+        ActiveItem = new CharaActiveRestraint();
+        SelectedLock = Padlocks.None;
+        PostButtonPress.Invoke();
     }
 
     private bool DisplayToastErrorAndReset(GagSpeakApiEc errorCode, Padlocks padlock, bool unlocking)
@@ -148,6 +157,7 @@ public class PairRestraintPadlockCombo : CkPadlockComboBase<CharaActiveRestraint
                 Svc.Logger.Warning($"UNK Padlock Error: {errorCode}.");
                 break;
         }
+
         ResetSelection();
         ResetInputs();
         return false;

--- a/ProjectGagSpeak/CustomCombos/Padlocks/PadlockRestrictionsClient.cs
+++ b/ProjectGagSpeak/CustomCombos/Padlocks/PadlockRestrictionsClient.cs
@@ -1,7 +1,5 @@
 using GagSpeak.Services;
-using GagSpeak.State.Listeners;
 using GagSpeak.State.Managers;
-using GagSpeak.Utils;
 using GagSpeak.WebAPI;
 using GagspeakAPI.Data;
 using GagspeakAPI.Extensions;
@@ -12,8 +10,9 @@ public class PadlockRestrictionsClient : CkPadlockComboBase<ActiveRestriction>
 {
     private readonly RestrictionManager _manager;
     private readonly SelfBondageService _selfBondage;
+
     public PadlockRestrictionsClient(ILogger log, RestrictionManager manager, SelfBondageService selfBondage)
-        : base(() => manager.ServerRestrictionData?.Restrictions ?? [], PadlockEx.ClientLocks, log)
+        : base(() => [..PadlockEx.ClientLocks], log)
     {
         _manager = manager;
         _selfBondage = selfBondage;
@@ -23,65 +22,66 @@ public class PadlockRestrictionsClient : CkPadlockComboBase<ActiveRestriction>
         => _manager.Storage.TryGetRestriction(item.Identifier, out var restriction) ? restriction.Label : "None";
 
     protected override bool DisableCondition(int layerIdx)
-        => Items[layerIdx].Identifier == Guid.Empty;
+        => ActiveItem.Identifier == Guid.Empty;
 
     public void DrawLockCombo(float width, int layerIdx, string tooltip)
-        => DrawLockCombo($"##ClientLock-{layerIdx}", width, layerIdx, string.Empty, tooltip, true);
+    {
+        ActiveItem = _manager.ServerRestrictionData?.Restrictions[layerIdx] ?? new ActiveRestriction();
+        DrawLockCombo($"##ClientLock-{layerIdx}", width, layerIdx, string.Empty, tooltip, true);
+    }
 
     public void DrawUnlockCombo(float width, int layerIdx, string tooltip)
-        => DrawUnlockCombo($"##ClientUnlock-{layerIdx}", width, layerIdx, string.Empty, tooltip);
+    {
+        ActiveItem = _manager.ServerRestrictionData?.Restrictions[layerIdx] ?? new ActiveRestriction();
+        DrawUnlockCombo($"##ClientUnlock-{layerIdx}", width, layerIdx, string.Empty, tooltip);
+    }
 
-    protected override async Task<bool> OnLockButtonPress(string label, int layerIdx)
+    protected override async Task OnLockButtonPress(string label, int layerIdx)
     {
         // return if we cannot lock.
-        if (!Items[layerIdx].CanLock())
-            return false;
+        if (!ActiveItem.CanLock())
+            return;
 
         // validate the lock, if it is not valid, we will display an error and reset inputs.
         if (!ValidateLock(layerIdx))
-            return false;
+            return;
 
         var time = SelectedLock is Padlocks.FiveMinutes ? DateTimeOffset.UtcNow.Add(TimeSpan.FromMinutes(5)) : Timer.GetEndTimeUTC();
-        var newData = Items[layerIdx] with { Padlock = SelectedLock, Password = Password, Timer = time, PadlockAssigner = MainHub.UID };
+        var newData = ActiveItem with { Padlock = SelectedLock, Password = Password, Timer = time, PadlockAssigner = MainHub.UID };
         if (await _selfBondage.DoSelfBindResult(layerIdx, newData, DataUpdateType.Locked))
         {
-            ResetSelection();
-            ResetInputs();
-            RefreshStorage(label);
-            return true;
+            ActiveItem = new ActiveRestriction();
         }
         else
         {
             Log.LogDebug($"Failed to perform LockRestriction with {SelectedLock.ToName()} on self.", LoggerType.StickyUI);
-            ResetSelection();
-            ResetInputs();
-            return false;
         }
+
+        ResetSelection();
+        ResetInputs();
     }
 
-    protected override async Task<bool> OnUnlockButtonPress(string label, int layerIdx)
+    protected override async Task OnUnlockButtonPress(string label, int layerIdx)
     {
         // make a general common sense assumption logic check here, the rest can be handled across the server.
-        if (!Items[layerIdx].CanUnlock())
-            return false;
+        if (!ActiveItem.CanUnlock())
+            return;
 
         if (!ValidateUnlock(layerIdx))
-            return false;
+            return;
 
-        var newData = Items[layerIdx] with { Padlock = Items[layerIdx].Padlock, Password = Items[layerIdx].Password, PadlockAssigner = MainHub.UID };
+        var newData = ActiveItem with { Padlock = ActiveItem.Padlock, Password = ActiveItem.Password, PadlockAssigner = MainHub.UID };
         if (await _selfBondage.DoSelfBindResult(layerIdx, newData, DataUpdateType.Unlocked))
         {
-            ResetSelection();
-            ResetInputs();
-            RefreshStorage(label);
-            return true;
+            ActiveItem = new ActiveRestriction();
+            SelectedLock = Padlocks.None;
         }
         else
         {
-            ResetSelection();
-            ResetInputs();
-            return false;
+            Log.LogDebug("Failed to perform UnlockRestriction on self.");
         }
+        ResetSelection();
+        ResetInputs();
     }
 
     private bool ValidateLock(int layerIdx)
@@ -131,12 +131,12 @@ public class PadlockRestrictionsClient : CkPadlockComboBase<ActiveRestriction>
     private bool ValidateUnlock(int layerIdx)
     {
         // Determine if we have access to unlock.
-        bool valid = Items[layerIdx].Padlock switch
+        bool valid = ActiveItem.Padlock switch
         {
             Padlocks.Metal or Padlocks.FiveMinutes or Padlocks.Timer => true,
-            Padlocks.Combination => Items[layerIdx].Password == Password,
-            Padlocks.Password => Items[layerIdx].Password == Password,
-            Padlocks.TimerPassword => Items[layerIdx].Password == Password,
+            Padlocks.Combination => ActiveItem.Password == Password,
+            Padlocks.Password => ActiveItem.Password == Password,
+            Padlocks.TimerPassword => ActiveItem.Password == Password,
             _ => false
         };
 
@@ -144,7 +144,7 @@ public class PadlockRestrictionsClient : CkPadlockComboBase<ActiveRestriction>
             return true;
 
         // If we don't, display the appropriate error and reset inputs.
-        switch (Items[layerIdx].Padlock)
+        switch (ActiveItem.Padlock)
         {
             case Padlocks.Combination:
             case Padlocks.Password:

--- a/ProjectGagSpeak/CustomCombos/Padlocks/PadlockRestrictionsPair.cs
+++ b/ProjectGagSpeak/CustomCombos/Padlocks/PadlockRestrictionsPair.cs
@@ -13,7 +13,7 @@ public class PairRestrictionPadlockCombo : CkPadlockComboBase<ActiveRestriction>
     private readonly MainHub _mainHub;
     private Kinkster _ref;
     public PairRestrictionPadlockCombo(ILogger log, MainHub hub, Kinkster k, Action postButtonPress)
-        : base(() => [..k.ActiveRestrictions.Restrictions], () => [..PadlockEx.GetLocksForPair(k.PairPerms)], log)
+        : base(() => [..PadlockEx.GetLocksForPair(k.PairPerms)], log)
     {
         _mainHub = hub;
         _ref = k;
@@ -23,13 +23,25 @@ public class PairRestrictionPadlockCombo : CkPadlockComboBase<ActiveRestriction>
     protected override string ItemName(ActiveRestriction item)
         => _ref.LightCache.Restrictions.TryGetValue(item.Identifier, out var bind) ? bind.Label : "None";
     protected override bool DisableCondition(int layerIdx)
-        => Items[layerIdx].Identifier == Guid.Empty;
+        => ActiveItem.Identifier == Guid.Empty;
 
-    protected override async Task<bool> OnLockButtonPress(string label, int layerIdx)
+    public override void DrawLockCombo(string label, float width, int layerIdx, string buttonTxt, string tooltip, bool isTwoRow)
+    {
+        ActiveItem = _ref.ActiveRestrictions.Restrictions[layerIdx];
+        base.DrawLockCombo(label, width, layerIdx, buttonTxt, tooltip, isTwoRow);
+    }
+
+    public override void DrawUnlockCombo(string label, float width, int layerIdx, string buttonTxt, string tooltip)
+    {
+        ActiveItem = _ref.ActiveRestrictions.Restrictions[layerIdx];
+        base.DrawUnlockCombo(label, width, layerIdx, buttonTxt, tooltip);
+    }
+
+    protected override async Task OnLockButtonPress(string label, int layerIdx)
     {
         // return if we cannot lock.
-        if (!Items[layerIdx].CanLock() || !_ref.PairPerms.LockRestrictions)
-            return false;
+        if (!ActiveItem.CanLock() || !_ref.PairPerms.LockRestrictions)
+            return;
 
         // we know it was valid, so begin assigning the new data to send off.
         var finalTime = SelectedLock == Padlocks.FiveMinutes
@@ -49,28 +61,26 @@ public class PairRestrictionPadlockCombo : CkPadlockComboBase<ActiveRestriction>
         {
             Log.LogDebug($"Failed to perform LockRestriction with {SelectedLock.ToName()} on {_ref.GetNickAliasOrUid()}, Reason:{LoggerType.StickyUI}");
             DisplayToastErrorAndReset(result.ErrorCode, SelectedLock, false);
-            return false;
         }
         else
         {
             Log.LogDebug($"Locking Restriction with {SelectedLock.ToName()} on {_ref.GetNickAliasOrUid()}", LoggerType.StickyUI);
             ResetSelection();
             ResetInputs();
-            RefreshStorage(label);
+            ActiveItem = new ActiveRestriction();
             PostButtonPress?.Invoke();
-            return true;
         }
     }
 
-    protected override async Task<bool> OnUnlockButtonPress(string label, int layerIdx)
+    protected override async Task OnUnlockButtonPress(string label, int layerIdx)
     {
-        if (!Items[layerIdx].CanUnlock() || !_ref.PairPerms.UnlockRestrictions)
-            return false;
+        if (!ActiveItem.CanUnlock() || !_ref.PairPerms.UnlockRestrictions)
+            return;
 
         var dto = new PushKinksterActiveRestriction(_ref.UserData, DataUpdateType.Unlocked)
         {
             Layer = layerIdx,
-            Padlock = Items[layerIdx].Padlock,
+            Padlock = ActiveItem.Padlock,
             Password = Password,
             PadlockAssigner = MainHub.UID,
         };
@@ -78,19 +88,17 @@ public class PairRestrictionPadlockCombo : CkPadlockComboBase<ActiveRestriction>
         var result = await _mainHub.UserChangeKinksterActiveRestriction(dto);
         if (result.ErrorCode is not GagSpeakApiEc.Success)
         {
-            Log.LogDebug($"Failed to perform UnlockRestriction with {Items[layerIdx].Padlock.ToName()} on {_ref.GetNickAliasOrUid()}, Reason:{LoggerType.StickyUI}");
-            DisplayToastErrorAndReset(result.ErrorCode, Items[layerIdx].Padlock, true);
-            return false;
+            Log.LogDebug($"Failed to perform UnlockRestriction with {ActiveItem.Padlock.ToName()} on {_ref.GetNickAliasOrUid()}, Reason:{LoggerType.StickyUI}");
+            DisplayToastErrorAndReset(result.ErrorCode, ActiveItem.Padlock, true);
         }
         else
         {
-            Log.LogDebug($"Unlocking Restriction with {Items[layerIdx].Padlock.ToName()} on {_ref.GetNickAliasOrUid()}", LoggerType.StickyUI);
+            Log.LogDebug($"Unlocking Restriction with {ActiveItem.Padlock.ToName()} on {_ref.GetNickAliasOrUid()}", LoggerType.StickyUI);
             ResetSelection();
             ResetInputs();
-            RefreshStorage(label);
+            ActiveItem = new ActiveRestriction();
             SelectedLock = Padlocks.None;
             PostButtonPress?.Invoke();
-            return true;
         }
     }
 


### PR DESCRIPTION
Refactored CkPadlockComboBase to reference a single item directly, instead of caching a cache. Should alleviate the "lock and unlock buttons are disabled after a reconnect" issue.

I was able to reproduce that by applying and removing an item, then reconnecting. When you reopen the wardrobe, that slot that had an item in it would have the lock selection and unlock button permanently disabled until the plugin was restarted.