### PR TITLE
Fix for block chat input not working.

### DIFF
--- a/ProjectGagSpeak/GameInternals/Addons/ChatLogAddon.cs
+++ b/ProjectGagSpeak/GameInternals/Addons/ChatLogAddon.cs
@@ -17,8 +17,9 @@ public static unsafe class AddonChatLog
 {
     private const uint TEXT_INPUT_CURSOR_ID = 2;
     private const uint TEXT_INPUT_NODE_ID = 5;
+    private const ushort TEXT_INPUT_INPUT_NODE_ID = 16;
 
-    /// <summary> 
+    /// <summary>
     ///     The Area in the Chat Box with the Chat-Input field and button row.
     /// </summary>
     private static AddonChatLogPanel* _mainChatLog => (AddonChatLogPanel*)(AtkUnitBase*)Svc.GameGui.GetAddonByName("ChatLog").Address;
@@ -54,6 +55,36 @@ public static unsafe class AddonChatLog
             RaptureAtkModule.Instance()->ClearFocus();
     }
 
+    public static void DisableInput(bool blockInput)
+    {
+        var node = (AtkComponentNode*)_mainChatLog->AtkUnitBase.GetNodeById(TEXT_INPUT_NODE_ID);
+        if (node is null) return;
+
+        var uldManager = node->Component->UldManager;
+        if (uldManager.NodeList is null) return;
+
+        AtkResNode* txtNode = null;
+        for (var i = 0; i < uldManager.NodeListCount; i++)
+        {
+            var tnode = uldManager.NodeList[i];
+            // If true, this is the TextInputCursorNode
+            if (tnode != null && tnode->NodeId == TEXT_INPUT_INPUT_NODE_ID)
+                txtNode = tnode;
+        }
+        if (txtNode is null) return;
+
+        if (blockInput)
+        {
+            node->NodeFlags &= ~(NodeFlags.Enabled | NodeFlags.Focusable);
+            txtNode->NodeFlags &= ~(NodeFlags.Enabled | NodeFlags.Focusable);
+        }
+        else
+        {
+            node->NodeFlags |= (NodeFlags.Enabled | NodeFlags.Focusable);
+            txtNode->NodeFlags |= (NodeFlags.Enabled | NodeFlags.Focusable);
+        }
+    }
+
     public static unsafe void SetChatInputVisibility(bool state)
     {
         if (HasValidRoot(_mainChatLog))
@@ -84,7 +115,7 @@ public static unsafe class AddonChatLog
     private static AtkResNode* GetChatInputCursorNode()
     {
         // Validate ChatInput Node
-        if(!HasValidRoot(_mainChatLog)) 
+        if(!HasValidRoot(_mainChatLog))
             return null;
 
         // Grab the TextInput Node & Validate path to UldManager.
@@ -108,4 +139,6 @@ public static unsafe class AddonChatLog
 
         return null;
     }
+
+
 }

--- a/ProjectGagSpeak/PlayerControl/Controllers/ChatboxController.cs
+++ b/ProjectGagSpeak/PlayerControl/Controllers/ChatboxController.cs
@@ -24,15 +24,13 @@ public sealed class ChatboxController : DisposableMediatorSubscriberBase
         _cache = cache;
 
         Mediator.Subscribe<HcStateCacheChanged>(this, _ => UpdateHardcoreStatus());
-        //Mediator.Subscribe<FrameworkUpdateMessage>(this, _ => FrameworkUpdate());
+        Mediator.Subscribe<FrameworkUpdateMessage>(this, _ => FrameworkUpdate());
         Svc.AddonLifecycle.RegisterListener(AddonEvent.PostShow, "ChatLog", ChatLogPostShow);
-        Svc.AddonLifecycle.RegisterListener(AddonEvent.PostFocusChanged, "ChatLog", ChatLogFocusChanged);
     }
 
     protected override void Dispose(bool disposing) {
         if (!disposing) return;
         Svc.AddonLifecycle.UnregisterListener(ChatLogPostShow);
-        Svc.AddonLifecycle.UnregisterListener(ChatLogFocusChanged);
         base.Dispose(disposing);
     }
 
@@ -46,24 +44,10 @@ public sealed class ChatboxController : DisposableMediatorSubscriberBase
             Svc.Framework.RunOnTick(() => AddonChatLog.SetChatPanelVisibility(!_hideChatBoxes), delayTicks:1);
     }
 
-    private void ChatLogFocusChanged(AddonEvent type, AddonArgs args)
+    private void FrameworkUpdate()
     {
-        if (_blockInput) 
-            AddonChatLog.EnsureNoChatInputFocus();
+        AddonChatLog.DisableInput(_blockInput);
     }
-
-    /* this shouldn't be necessary any more, let's test.
-    private unsafe void FrameworkUpdate()
-    {
-        // assuming that this causes issues when ran outside framework 
-        // todo: move this to addon.lifecycle events when we figure out how
-        if (_blockInput)
-            AddonChatLog.EnsureNoChatInputFocus();
-        if (_hideChatBoxes)
-            AddonChatLog.SetChatPanelVisibility(false);
-        if (_hideChatInput)
-            AddonChatLog.SetChatInputVisibility(false);
-    } */
 
     // Update our local value to reflect the latest state in the cache.
     public void UpdateHardcoreStatus()

--- a/ProjectGagSpeak/PlayerControl/Controllers/ChatboxController.cs
+++ b/ProjectGagSpeak/PlayerControl/Controllers/ChatboxController.cs
@@ -48,6 +48,7 @@ public sealed class ChatboxController : DisposableMediatorSubscriberBase
     private void FrameworkUpdate()
     {
         if (_blockingInput == _blockInput) return;
+        Logger.LogTrace($"Chat input block changed to {_blockInput}. Correcting text box state.", LoggerType.HardcoreActions);
         AddonChatLog.DisableInput(_blockInput);
         _blockingInput = _blockInput;
     }

--- a/ProjectGagSpeak/PlayerControl/Controllers/ChatboxController.cs
+++ b/ProjectGagSpeak/PlayerControl/Controllers/ChatboxController.cs
@@ -32,6 +32,7 @@ public sealed class ChatboxController : DisposableMediatorSubscriberBase
     protected override void Dispose(bool disposing) {
         if (!disposing) return;
         Svc.AddonLifecycle.UnregisterListener(ChatLogPostShow);
+        AddonChatLog.DisableInput(false); // restore access to chat input if we're disabling
         base.Dispose(disposing);
     }
 

--- a/ProjectGagSpeak/PlayerControl/Controllers/ChatboxController.cs
+++ b/ProjectGagSpeak/PlayerControl/Controllers/ChatboxController.cs
@@ -15,6 +15,7 @@ public sealed class ChatboxController : DisposableMediatorSubscriberBase
 {
     private readonly PlayerControlCache _cache;
     private bool _blockInput = false;
+    private bool _blockingInput = false;
     private bool _hideChatBoxes = false;
     private bool _hideChatInput = false;
 
@@ -46,7 +47,9 @@ public sealed class ChatboxController : DisposableMediatorSubscriberBase
 
     private void FrameworkUpdate()
     {
+        if (_blockingInput == _blockInput) return;
         AddonChatLog.DisableInput(_blockInput);
+        _blockingInput = _blockInput;
     }
 
     // Update our local value to reflect the latest state in the cache.


### PR DESCRIPTION
Changes it so it toggles the enable state instead of just clearing focus, chat won't be clickable and won't show the text input cursor now.