### PR TITLE
feat: Add Pair Request notification to Interaction UI

### DIFF
--- a/ProjectGagSpeak/State/Handlers/CallbackHandler.cs
+++ b/ProjectGagSpeak/State/Handlers/CallbackHandler.cs
@@ -445,5 +445,19 @@ public sealed class CallbackHandler : DisposableMediatorSubscriberBase
 
         PostActionMsg(pairUid, InteractionType.ListenerName, $"Obtained Listener name from Kinkster");
     }
+    
+    public Task ReceivedPairRequest(KinksterRequest dto)
+    {
+        if (!MainHub.IsConnectionDataSynced)
+            return Task.CompletedTask;
+        
+        Logger.LogTrace("Received pair request from server!", LoggerType.PairManagement);
+        var message = $"Received a new pair request from {dto.User.AnonName}";
+        if (dto.Details.Message.Length > 0)
+            message = $"{dto.Details.Message}";
+        
+        Mediator.Publish(new EventMessage(new(dto.User.AnonName, dto.User.AnonName, InteractionType.PairRequestReceived, message)));
+        return Task.CompletedTask;
+    }
 
 }

--- a/ProjectGagSpeak/WebAPI/Hubs/MainHub.ApiCallbacks.cs
+++ b/ProjectGagSpeak/WebAPI/Hubs/MainHub.ApiCallbacks.cs
@@ -109,6 +109,7 @@ public partial class MainHub
     {
         Logger.LogDebug($"Callback_AddPairRequest: {dto}", LoggerType.Callbacks);
         _requests.AddNewRequest(dto);
+        _callbackHandler.ReceivedPairRequest(dto);
         return Task.CompletedTask;
     }
 


### PR DESCRIPTION
I added pairing requests to the interaction window notification UI because I was missing requests as I don't check the main UI often enough.

I also had it where it would show a toast/chat informational message on the request but removed it for this PR.

Requires: https://github.com/Project-GagSpeak/api/pull/3

Let me know if this shouldn't be a thing.