### PR TITLE
QoL - Expand settings for auto-removal based on timer

### DIFF
--- a/ProjectGagSpeak/Localization/Strings.cs
+++ b/ProjectGagSpeak/Localization/Strings.cs
@@ -1149,6 +1149,9 @@ namespace GagSpeak.Localization
         public readonly string RestrictionGlamours = Loc.Localize("MainOptions_RestrictionGlamours", "Restriction Glamours");
         public readonly string RestrictionGlamoursTT = Loc.Localize("MainOptions_RestrictionGlamoursTT", "Allows Glamourer to apply restraint glamour items from your Restraint Storage." +
             "--SEP--Restraint glamours can be created in the Wardrobe Interface.");
+        
+        public readonly string RestrictionPadlockTimer = Loc.Localize("MainOptions_RestrictionPadlockTimer", "Expired Timer Restriction Removal");
+        public readonly string RestrictionPadlockTimerTT = Loc.Localize("MainOptions_RestrictionPadlockTimerTT", "Automatically removes locked restrictions when the timer expires.");
 
         public readonly string RestraintSetGlamour = Loc.Localize("MainOptions_RestraintSetGlamour", "Restraint Glamours");
         public readonly string RestraintSetGlamourTT = Loc.Localize("MainOptions_RestraintSetGlamourTT", "Allows Glamourer to apply restraints from your Restraint Sets." +

--- a/ProjectGagSpeak/PlayerClient/Storages/GagspeakConfig.cs
+++ b/ProjectGagSpeak/PlayerClient/Storages/GagspeakConfig.cs
@@ -55,9 +55,11 @@ public class GagspeakConfig
     public GarbleCoreLang Language { get; set; } = GarbleCoreLang.English; // MuffleCore
     public GarbleCoreDialect LanguageDialect { get; set; } = GarbleCoreDialect.US; // MuffleCore
     
-    public bool CursedLootUI { get; set; } = false; // CursedLootUI
-    public bool CursedItemsApplyTraits { get; set; } = false; // If Mimics can apply restriction traits to you.
-    public bool RemoveRestrictionOnTimerExpire { get; set; } = false; // Auto-Remove Items when timer falloff occurs.
+    public bool CursedLootUI { get; set; } = false;                   // CursedLootUI
+    public bool CursedItemsApplyTraits { get; set; } = false;         // If Mimics can apply restriction traits to you.
+    public bool RemoveGagOnTimerExpire { get; set; } = false; // Auto-Remove Items when timer falloff occurs.
+    public bool RemoveRestrictionOnTimerExpire { get; set; } = false; // Auto-Remove Restriction when timer falloff occurs.
+    public bool RemoveRestraintOnTimerExpire { get; set; } = false; // Auto-Remove restraint when timer falloff occurs.
 
     // GLOBAL TOYBOX SETTINGS
     // public OutputType AudioOutputType { get; set; } = OutputType.DirectSound; // Best for FFXIV.

--- a/ProjectGagSpeak/Services/AutoUnlockService.cs
+++ b/ProjectGagSpeak/Services/AutoUnlockService.cs
@@ -199,7 +199,7 @@ public sealed class AutoUnlockService : BackgroundService
                 _mediator.Publish(new EventMessage(new("Auto-Unlock", MainHub.UID, InteractionType.UnlockGag, $"{gag.GagItem.GagName()}'s Timed Padlock Expired!")));
 
                 // Auto remove Gag if configured to do so.
-                if (_config.Current.RemoveRestrictionOnTimerExpire && await _dds.PushNewActiveGagSlot(index, new ActiveGagSlot(), DataUpdateType.Removed).ConfigureAwait(false) is not null)
+                if (_config.Current.RemoveGagOnTimerExpire && await _dds.PushNewActiveGagSlot(index, new ActiveGagSlot(), DataUpdateType.Removed).ConfigureAwait(false) is not null)
                 {
                     // _mediator.Publish(new GagStateChanged(NewState.Disabled, index, backup, MainHub.UID, MainHub.UID));
                     if (_gags.RemoveGag(index, MainHub.UID, out var visualItem))
@@ -240,6 +240,14 @@ public sealed class AutoUnlockService : BackgroundService
             {
                 _mediator.Publish(new RestrictionStateChanged(NewState.Unlocked, index, backup, MainHub.UID, MainHub.UID));
                 _mediator.Publish(new EventMessage(new("Auto-Unlock", MainHub.UID, InteractionType.UnlockRestriction, $"Restriction Layer {index + 1}'s Timed Padlock Expired!")));
+                
+                // Auto remove if configured to do so.
+                if (_config.Current.RemoveRestrictionOnTimerExpire && await _dds.PushNewActiveRestriction(index, new ActiveRestriction(), DataUpdateType.Removed).ConfigureAwait(false) is not null)
+                {
+                    if (_restrictions.RemoveRestriction(index, MainHub.UID, out var visualItem))
+                        await _cacheManager.RemoveRestrictionItem(visualItem, index);
+                    _logger.LogInformation($"Restriction Layer {index + 1} Removed due to Timer Expire!", LoggerType.AutoUnlocks);
+                }
             }
             else
             {
@@ -276,6 +284,14 @@ public sealed class AutoUnlockService : BackgroundService
         {
             _mediator.Publish(new RestraintStateChanged(NewState.Unlocked, backup, MainHub.UID, MainHub.UID));
             _mediator.Publish(new EventMessage(new("Auto-Unlock", MainHub.UID, InteractionType.UnlockRestraint, $"Active RestraintSet's Timed Padlock Expired!")));
+            
+            // Auto remove if configured to do so.
+            if (_config.Current.RemoveRestrictionOnTimerExpire && await _dds.PushNewActiveRestraint(new CharaActiveRestraint(), DataUpdateType.Removed).ConfigureAwait(false) is not null)
+            {
+                if (_restraints.Remove(MainHub.UID, out var restraintSet, out var removedLayers))
+                    await _cacheManager.RemoveRestraintSet(restraintSet, removedLayers);
+                _logger.LogInformation($"RestraintSet Removed due to Timer Expire!", LoggerType.AutoUnlocks);
+            }
         }
         else
         {

--- a/ProjectGagSpeak/Services/Config/ConfigMigrator.cs
+++ b/ProjectGagSpeak/Services/Config/ConfigMigrator.cs
@@ -80,7 +80,7 @@ public static class ConfigMigrator
 
 
         config["CursedLootUI"] = mainConfig["CursedDungeonLoot"];
-        config["RemoveRestrictionOnTimerExpire"] = mainConfig["RemoveGagUponLockExpiration"];
+        config["RemoveGagOnTimerExpire"] = mainConfig["RemoveGagUponLockExpiration"];
         config["VibratorMode"] = mainConfig["VibratorMode"];
         config["VibeSimAudio"] = mainConfig["VibeSimAudio"];
         config["IntifaceAutoConnect"] = mainConfig["IntifaceAutoConnect"];

--- a/ProjectGagSpeak/UI/Settings/SettingsUi.cs
+++ b/ProjectGagSpeak/UI/Settings/SettingsUi.cs
@@ -249,7 +249,7 @@ public class SettingsUi : WindowMediatorSubscriberBase
         var liveChatGarblerActive = globals.ChatGarblerActive;
         var gaggedNamePlates = globals.GaggedNameplate;
         var gagVisuals = globals.GagVisuals;
-        var removeGagOnLockExpiration = _mainConfig.Current.RemoveRestrictionOnTimerExpire;
+        var removeGagOnLockExpiration = _mainConfig.Current.RemoveGagOnTimerExpire;
 
         CkGui.FontText(GSLoc.Settings.MainOptions.HeaderGags, Fonts.UidFont);
         using (ImRaii.Disabled(globals.ChatGarblerLocked))
@@ -269,7 +269,7 @@ public class SettingsUi : WindowMediatorSubscriberBase
 
         if (ImGui.Checkbox(GSLoc.Settings.MainOptions.GagPadlockTimer, ref removeGagOnLockExpiration))
         {
-            _mainConfig.Current.RemoveRestrictionOnTimerExpire = removeGagOnLockExpiration;
+            _mainConfig.Current.RemoveGagOnTimerExpire = removeGagOnLockExpiration;
             _mainConfig.Save();
         }
         CkGui.HelpText(GSLoc.Settings.MainOptions.GagPadlockTimerTT);
@@ -282,6 +282,8 @@ public class SettingsUi : WindowMediatorSubscriberBase
         var restraintSetVisuals = globals.RestraintSetVisuals;
         var cursedDungeonLoot = _mainConfig.Current.CursedLootUI;
         var mimicsApplyTraits = _mainConfig.Current.CursedItemsApplyTraits;
+        var removeRestrictionOnLockExpiration = _mainConfig.Current.RemoveRestrictionOnTimerExpire;
+        var removeRestraintOnLockExpiration = _mainConfig.Current.RemoveRestraintOnTimerExpire;
 
         ImGui.Separator();
         CkGui.FontText(GSLoc.Settings.MainOptions.HeaderWardrobe, Fonts.UidFont);
@@ -316,10 +318,24 @@ public class SettingsUi : WindowMediatorSubscriberBase
             if (ImGui.Checkbox(GSLoc.Settings.MainOptions.RestrictionGlamours, ref restrictionVisuals))
                 AssignGlobalPermChangeTask(nameof(GlobalPerms.RestrictionVisuals), restrictionVisuals);
             CkGui.HelpText(GSLoc.Settings.MainOptions.RestrictionGlamoursTT);
+            
+            if (ImGui.Checkbox(GSLoc.Settings.MainOptions.RestrictionPadlockTimer, ref removeRestrictionOnLockExpiration))
+            {
+                _mainConfig.Current.RemoveRestrictionOnTimerExpire = removeRestrictionOnLockExpiration;
+                _mainConfig.Save();
+            }
+            CkGui.HelpText(GSLoc.Settings.MainOptions.RestrictionPadlockTimerTT);
 
             if (ImGui.Checkbox(GSLoc.Settings.MainOptions.RestraintSetGlamour, ref restraintSetVisuals))
                 AssignGlobalPermChangeTask(nameof(GlobalPerms.RestraintSetVisuals), restraintSetVisuals);
             CkGui.HelpText(GSLoc.Settings.MainOptions.RestraintSetGlamourTT);
+            
+            if (ImGui.Checkbox(GSLoc.Settings.MainOptions.RestraintPadlockTimer, ref removeRestraintOnLockExpiration))
+            {
+                _mainConfig.Current.RemoveRestraintOnTimerExpire = removeRestraintOnLockExpiration;
+                _mainConfig.Save();
+            }
+            CkGui.HelpText(GSLoc.Settings.MainOptions.RestraintPadlockTimerTT);
 
             if (ImGui.Checkbox(GSLoc.Settings.MainOptions.CursedLootActive, ref cursedDungeonLoot))
             {


### PR DESCRIPTION
This pull request introduces new two new settings for the automatic removal of restrictions and restraints (just like how auto gag removal works).

Note: Because I renamed the variable that the gag setting currently uses to have it make sense, users will need to enable it again if they had it previously enabled.