### PR TITLE
fix: refresh mod combo when penumbra mods change

### DIFF
--- a/ProjectGagSpeak/CustomCombos/EditorCombos/ModCombo.cs
+++ b/ProjectGagSpeak/CustomCombos/EditorCombos/ModCombo.cs
@@ -17,6 +17,11 @@ public sealed class ModCombo : CkFilterComboCache<ModInfo>
         SearchByParts = false;
     }
 
+    public void SetDirty()
+    {
+        Cleanup();
+    }
+
     protected override int UpdateCurrentSelected(int currentSelected)
     {
         if (Current?.DirPath == _currentPath)

--- a/ProjectGagSpeak/Interop/Ipc/IpcCallerPenumbra.cs
+++ b/ProjectGagSpeak/Interop/Ipc/IpcCallerPenumbra.cs
@@ -281,8 +281,8 @@ public class IpcCallerPenumbra : DisposableMediatorSubscriberBase, IIpcCaller
             return (new ModInfo(), new());
 
         var currentSettings = GetModSettingsSelected.Invoke(collection.Value.Id, directory);
-        if (currentSettings.Item1 is not PenumbraApiEc.Success || !currentSettings.Item2.HasValue)
-            return (new ModInfo(), new());
+        var priority = currentSettings.Item2.HasValue ? currentSettings.Item2.Value.Item2 : 0;
+        var currentOptions = currentSettings.Item2.HasValue ? currentSettings.Item2.Value.Item3 : new Dictionary<string, List<string>>();
 
         var modPathRes = GetModPath.Invoke(directory);
         if (modPathRes.Item1 is not PenumbraApiEc.Success)
@@ -293,8 +293,8 @@ public class IpcCallerPenumbra : DisposableMediatorSubscriberBase, IIpcCaller
             ? allSettingsResult.ToDictionary(t => t.Key, t => t.Value)
             : new();
 
-        var modInfo = new ModInfo(directory, modName, modPathRes.Item2, currentSettings.Item2.Value.Item2, allSettings);
-        return (modInfo, currentSettings.Item2.Value.Item3);
+        var modInfo = new ModInfo(directory, modName, modPathRes.Item2, priority, allSettings);
+        return (modInfo, currentOptions);
     }
 
 

--- a/ProjectGagSpeak/State/Managers/CacheManagers/ModSettingPresetManager.cs
+++ b/ProjectGagSpeak/State/Managers/CacheManagers/ModSettingPresetManager.cs
@@ -161,11 +161,16 @@ public class ModPresetManager : DisposableMediatorSubscriberBase, IHybridSavable
 
     public void OnModDirChanged(string oldPath, ModInfo newInfo, Dictionary<string, List<string>> latestCurrentOptions)
     {
-        // firstly, if the old path is not present, just return.
+        // update ModData so the combo reflects the new path immediately.
+        ModData = ModData.Where(m => m.DirPath != oldPath).Append(newInfo).ToList();
+        ModCombo.SetDirty();
+        PresetCombo.SetDirty();
+
+        // if the old path has no container, nothing else to update.
         if (ModPresetStorage.ByDirectory(oldPath) is not { } container)
             return;
 
-        // if there is a change, resync the contents with the updated data.
+        // resync the container with the updated path and settings.
         container.SyncWithPenumbraInfo(newInfo, latestCurrentOptions);
         _saver.Save(this);
         Mediator.Publish(new ConfigModPresetChanged(StorageChangeType.Modified, container));
@@ -173,11 +178,13 @@ public class ModPresetManager : DisposableMediatorSubscriberBase, IHybridSavable
 
     public void OnModAdded(ModInfo info, Dictionary<string, List<string>> currentOptions)
     {
-        // If a container does not yet exist for the mod, then create it.
+        // update ModData so the combo picks up the new mod without needing a restart.
+        ModData = ModData.Where(m => m.DirPath != info.DirPath).Append(info).ToList();
+
+        // if a container does not yet exist for the mod, create it.
         if (ModPresetStorage.ByDirectory(info.DirPath) is not { } container)
         {
             Logger.LogTrace($"No Container in storage exists for: {info.ToString()}");
-            // Create a new container object for the mod.
             container = new ModPresetContainer(info);
             ModPresetStorage.Add(container);
             var preset = new ModSettingsPreset(container) { Label = "Current", ModSettings = currentOptions };
@@ -192,21 +199,28 @@ public class ModPresetManager : DisposableMediatorSubscriberBase, IHybridSavable
             _saver.Save(this);
             Mediator.Publish(new ConfigModPresetChanged(StorageChangeType.Created, container));
         }
+
+        ModCombo.SetDirty();
+        PresetCombo.SetDirty();
     }
 
     public void OnModRemoved(string dirPath)
     {
-        // Remove all presets from the container, and then the container itself.
+        // remove from ModData first so the combo stops listing it.
+        ModData = ModData.Where(m => m.DirPath != dirPath).ToList();
+
+        // remove all presets from the container, then the container itself.
         if (ModPresetStorage.FirstOrDefault(x => x.DirectoryPath == dirPath) is { } container)
         {
             Logger.LogTrace($"Removing Mod Preset Container for {container.ModName} ({dirPath})");
-            // Remove all presets from the container
             container.ModPresets.Clear();
             ModPresetStorage.Remove(container);
-            // Optionally, save and notify
             _saver.Save(this);
             Mediator.Publish(new ConfigModPresetChanged(StorageChangeType.Deleted, container));
         }
+
+        ModCombo.SetDirty();
+        PresetCombo.SetDirty();
     }
 
 


### PR DESCRIPTION
## what

the associated mod dropdown in restrictions, gags and restraints doesn't
detect newly installed penumbra mods you had to disable and reenable
gagspeak entirely for the mod list to refresh.

## why

the `ModCombo` uses a `LazyList` that caches its items on first build and
never invalidates. the penumbra ipc events (ModAdded, ModDeleted, ModMoved)
were hooked up in `ModListener` and reached `ModPresetManager` but:

- `ModData` was only updated on initial penumbra load, not on later events
- neither `ModCombo` nor `PresetCombo` were told to flush their cache
- `IpcCallerPenumbra.GetModInfo` returned an empty ModInfo when the mod
  wasn't in the currently active collection, so ModData stayed desynced

## fix

- `ModCombo`: expose a `SetDirty()` that calls `Cleanup()` to invalidate
  the lazy cache (mirrors what `ModPresetCombo.SetDirty` already did)
- `ModPresetManager`: in `OnModAdded`, `OnModRemoved` and `OnModDirChanged`,
  update the `ModData` list and call `SetDirty()` on both combos
- `IpcCallerPenumbra.GetModInfo`: return a valid `ModInfo` even when the
  mod isn't in the current collection, so the cache can track it

## testing

- installed a new mod in penumbra while gagspeak is running
- opened a restriction/gag/restraint and the new mod now appears in the
  associated mod dropdown without reloading the plugin
- removed a mod in penumbra, it disappears from the dropdown
- renamed a mod directory, it updates live