### PR TITLE
Per-item cursed lock time ranges.

### DIFF
--- a/ProjectGagSpeak/State/Handlers/LootHandler.cs
+++ b/ProjectGagSpeak/State/Handlers/LootHandler.cs
@@ -144,16 +144,16 @@ public sealed class LootHandler
         // Now correct the bounds. We bound that isn't set by the item equal to that of the bound that is. 
         if (lower > upper && item.TimeRangeLower.HasValue && !item.TimeRangeUpper.HasValue)
         {
-            upper = lower;                                                      
+            return lower;                                                      
         }
         else if (lower > upper && !item.TimeRangeLower.HasValue && item.TimeRangeUpper.HasValue)
         {
-            lower = upper;
+            return upper;
         }
         else if (lower > upper)
         {
             // This shouldn't happen, but let's just use the smaller value for both bounds. Tho, the smaller one is the upper bound, so we will use that for both.
-            lower = upper;
+            return upper;
         }
         return Generators.GetRandomTimeSpan(lower, upper);
     }

--- a/ProjectGagSpeak/State/Handlers/LootHandler.cs
+++ b/ProjectGagSpeak/State/Handlers/LootHandler.cs
@@ -132,6 +132,32 @@ public sealed class LootHandler
         await ApplyCursedLoot().ConfigureAwait(false);
     }
 
+    private TimeSpan getTimeSpanForItem(CursedItem? item)
+    {
+        // The way this will work as as follows: If the item has no time at all, we simply use the global range, otherwise, we use the items range. Item's range will always be used if it exists.
+        if (item == null) return TimeSpan.Zero; // Should never happen, but just in case.
+
+        // Now, get the lower and upper bounds for the item. Use global range if the item has no bounds set.
+        TimeSpan lower = item.TimeRangeLower ?? _manager.LockRangeLower;
+        TimeSpan upper = item.TimeRangeUpper ?? _manager.LockRangeUpper;
+
+        // Now correct the bounds. We bound that isn't set by the item equal to that of the bound that is. 
+        if (lower > upper && item.TimeRangeLower.HasValue && !item.TimeRangeUpper.HasValue)
+        {
+            upper = lower;                                                      
+        }
+        else if (lower > upper && !item.TimeRangeLower.HasValue && item.TimeRangeUpper.HasValue)
+        {
+            lower = upper;
+        }
+        else if (lower > upper)
+        {
+            // This shouldn't happen, but let's just use the smaller value for both bounds. Tho, the smaller one is the upper bound, so we will use that for both.
+            lower = upper;
+        }
+        return Generators.GetRandomTimeSpan(lower, upper);
+    }
+
     private async Task ApplyCursedLoot()
     {
         // run our first roll, return if not in range.
@@ -150,7 +176,7 @@ public sealed class LootHandler
         var chosen = validItems[chosenIdx];
 
         // Calculate the timespan to apply the lock for.
-        var lockTime = Generators.GetRandomTimeSpan(_manager.LockRangeLower, _manager.LockRangeUpper);
+        var lockTime = getTimeSpanForItem(chosen);
 
         // If the chosen item is a gag, and there is space to apply one, apply the gag item.
         // (This will fail if it is a restriction item that was selected).

--- a/ProjectGagSpeak/State/Managers/CacheManagers/CursedLootManager.cs
+++ b/ProjectGagSpeak/State/Managers/CacheManagers/CursedLootManager.cs
@@ -365,7 +365,9 @@ public sealed class CursedLootManager : IHybridSavable
                 ReleaseTime = new DateTimeOffset(releaseTime, TimeSpan.Zero),
                 Precedence = Enum.TryParse<Precedence>(token["Precedence"]?.Value<string>(), out var precedence) ? precedence : Precedence.Default,
                 ApplyTraits = token["ApplyTraits"]?.Value<bool>() ?? true,
-                RefItem = gagRef
+                RefItem = gagRef,
+                TimeRangeLower = TimeSpan.TryParse(token["TimeRangeLower"]?.Value<string>(), out var lower) ? lower : null,
+                TimeRangeUpper = TimeSpan.TryParse(token["TimeRangeUpper"]?.Value<string>(), out var upper) ? upper : null
             };
             return item;
         }
@@ -402,7 +404,9 @@ public sealed class CursedLootManager : IHybridSavable
                 ReleaseTime = new DateTimeOffset(releaseTime, TimeSpan.Zero),
                 Precedence = Enum.TryParse<Precedence>(token["Precedence"]?.Value<string>(), out var precedence) ? precedence : Precedence.Default,
                 ApplyTraits = token["ApplyTraits"]?.Value<bool>() ?? true,
-                RefItem = restRef
+                RefItem = restRef,
+                TimeRangeLower = TimeSpan.TryParse(token["TimeRangeLower"]?.Value<string>(), out var lower) ? lower : null,
+                TimeRangeUpper = TimeSpan.TryParse(token["TimeRangeUpper"]?.Value<string>(), out var upper) ? upper : null
             };
             return item;
         }

--- a/ProjectGagSpeak/State/_Models/CursedItem.cs
+++ b/ProjectGagSpeak/State/_Models/CursedItem.cs
@@ -17,6 +17,9 @@ public abstract class CursedItem : IEditableStorageItem<CursedItem>
     public Precedence Precedence { get; set; } = Precedence.Default; // the priority system.
     public bool ApplyTraits { get; set; } = true; // For Hardcore Traits.
 
+    public TimeSpan? TimeRangeLower { get; set; } = null;
+    public TimeSpan? TimeRangeUpper { get; set; } = null;
+
     public abstract string RefLabel { get; }
 
     public CursedItem()
@@ -38,6 +41,8 @@ public abstract class CursedItem : IEditableStorageItem<CursedItem>
         ReleaseTime = other.ReleaseTime;
         Precedence = other.Precedence;
         ApplyTraits = other.ApplyTraits;
+        TimeRangeLower = other.TimeRangeLower;
+        TimeRangeUpper = other.TimeRangeUpper;
     }
 
     // May need to be moved up or something. Not sure though. Look into later.
@@ -118,7 +123,9 @@ public class CursedGagItem : CursedItem
             ["ReleaseTime"] = ReleaseTime.UtcDateTime.ToString("o"),
             ["Precedence"] = Precedence.ToString(),
             ["GagRef"] = RefItem.GagType.ToString(),
-            ["ApplyTraits"] = ApplyTraits
+            ["ApplyTraits"] = ApplyTraits,
+            ["TimeRangeLower"] = TimeRangeLower.ToString(),
+            ["TimeRangeUpper"] = TimeRangeUpper.ToString()
         };
 }
 
@@ -170,6 +177,8 @@ public class CursedRestrictionItem : CursedItem
             ["ReleaseTime"] = ReleaseTime.UtcDateTime.ToString("o"),
             ["Precedence"] = Precedence.ToString(),
             ["RestrictionRef"] = RefItem.Identifier.ToString(),
-            ["ApplyTraits"] = ApplyTraits
+            ["ApplyTraits"] = ApplyTraits,
+            ["TimeRangeLower"] = TimeRangeLower.ToString(),
+            ["TimeRangeUpper"] = TimeRangeUpper.ToString()
         };
 }

--- a/ProjectGagSpeak/UI/Modules/CursedLoot/LootItemsTab.cs
+++ b/ProjectGagSpeak/UI/Modules/CursedLoot/LootItemsTab.cs
@@ -3,6 +3,7 @@ using CkCommons.Gui;
 using CkCommons.Gui.Utility;
 using CkCommons.Raii;
 using CkCommons.Widgets;
+using CkCommons.Helpers;
 using Dalamud.Bindings.ImGui;
 using Dalamud.Interface.Colors;
 using Dalamud.Interface.Utility.Raii;
@@ -70,7 +71,7 @@ public class LootItemsTab : IFancyTab
         ImUtf8.SameLineInner();
         using (ImRaii.Group())
         {
-            DrawSelectedItem(CkStyle.GetFrameRowsHeight(5), rounding);
+            DrawSelectedItem(CkStyle.GetFrameRowsHeight(7), rounding);
             DrawStatistics(rounding);
         }
     }
@@ -182,6 +183,8 @@ public class LootItemsTab : IFancyTab
         if (ImGui.Checkbox("Apply Traits", ref doTraits))
             item.ApplyTraits = doTraits;
         CkGui.AttachTooltip("If the cursed Loot should apply the item's attached hardcore traits.");
+
+        DrawIndividualTimeSpan(item);
     }
 
     private void DrawSetupOverview(Vector2 region, float rounding)
@@ -230,6 +233,12 @@ public class LootItemsTab : IFancyTab
         // Trait Application.
         CkGui.BoolIcon(selected.ApplyTraits, false);
         CkGui.TextFrameAlignedInline(selected.ApplyTraits ? "Applies traits" : "Ignores traits");
+
+        // Time Range.
+        var minTime = selected.TimeRangeLower?.ToGsRemainingTime() ?? "Not Set";
+        var maxTime = selected.TimeRangeUpper?.ToGsRemainingTime() ?? "Not Set";
+        CkGui.TextFrameAligned("Minimum Time: " + minTime);
+        CkGui.TextFrameAligned("Maximum Time: " + maxTime);
     }
 
     private void DrawBindLootEditor(Vector2 region, CursedRestrictionItem item, float rounding)
@@ -286,5 +295,42 @@ public class LootItemsTab : IFancyTab
         if (ImGui.Checkbox("Apply Traits", ref doTraits))
             item.ApplyTraits = doTraits;
         CkGui.AttachTooltip("If the ref item's hardcore traits are applied.");
+
+        DrawIndividualTimeSpan(item);
+    }
+
+    private void DrawIndividualTimeSpan(CursedItem item)
+    {
+        var minTimeString = item.TimeRangeLower?.ToGsRemainingTime() ?? "";
+        ImGui.InputTextWithHint("##ItemMinTime", "Min Time", ref minTimeString, 64);
+        if (ImGui.IsItemDeactivatedAfterEdit())
+        {
+
+            if (minTimeString != "" && RegexEx.TryParseTimeSpan(minTimeString, out var newLower))
+            {
+                if (!item.TimeRangeUpper.HasValue || newLower <= item.TimeRangeUpper) item.TimeRangeLower = newLower;
+            }
+            else
+            {
+                item.TimeRangeLower = null; // We can either keep it 0s or null, but null is more appropriate for "no minimum time set" Aka. Try to use the global range instead.
+            }
+        }
+        CkGui.AttachTooltip("The minimum time for the item. Will override the default time if set.");
+
+        var maxTimeString = item.TimeRangeUpper?.ToGsRemainingTime() ?? "";
+        ImGui.InputTextWithHint("##ItemMaxTime", "Max Time", ref maxTimeString, 64);
+        if (ImGui.IsItemDeactivatedAfterEdit())
+        {
+
+            if (maxTimeString != "" && RegexEx.TryParseTimeSpan(maxTimeString, out var newUpper))
+            {
+                if(!item.TimeRangeLower.HasValue || newUpper >= item.TimeRangeLower) item.TimeRangeUpper = newUpper;
+            }
+            else if (maxTimeString == "")
+            {
+                item.TimeRangeUpper = null; // We can either keep it 0s or null, but null is more appropriate for "no maximum time set" Aka. Try to use the global range instead.
+            }
+        }
+        CkGui.AttachTooltip("The maximum time for the item. Will override the default time if set.");
     }
 }

--- a/ProjectGagSpeak/UI/Modules/CursedLoot/LootPoolTab.cs
+++ b/ProjectGagSpeak/UI/Modules/CursedLoot/LootPoolTab.cs
@@ -161,6 +161,12 @@ public class LootPoolTab : IFancyTab
         CkGui.ColorText("Unlocks At:", ImGuiColors.ParsedGold);
         CkGui.TextInline(item.ReleaseTime == DateTimeOffset.MinValue ? "<Not Applied>" : item.ReleaseTime.ToLocalTime().ToString("G"));
 
+        CkGui.ColorText("Minimum Time:", ImGuiColors.ParsedGold);
+        CkGui.TextInline(!item.TimeRangeLower.HasValue ? "<No Override Set>" : item.TimeRangeLower.Value.ToGsRemainingTime());
+
+        CkGui.ColorText("Maximum Time:", ImGuiColors.ParsedGold);
+        CkGui.TextInline(!item.TimeRangeUpper.HasValue ? "<No Override Set>" : item.TimeRangeUpper.Value.ToGsRemainingTime());
+
         ImGui.EndTooltip();
     }
 }


### PR DESCRIPTION
This feature would allow cursed items to override the global cursed lock range when applying.

The idea behind this feature was that you may feel more comfortable being stuck in a one item than an other, This feature allows you to more closely specify those times. Items with time overrides will simply lock for the times allowed by their individual ranges instead of the globally defined ranges.