### PR TITLE
Proposal: Change Layer dropdown in interactions UI to more informative button selection.

### DIFF
--- a/ProjectGagSpeak/UI/MainUi/SidePanel/SidePanelKinkster/SidePanelPair.Interactions.cs
+++ b/ProjectGagSpeak/UI/MainUi/SidePanel/SidePanelKinkster/SidePanelPair.Interactions.cs
@@ -13,6 +13,7 @@ using GagSpeak.Services.Mediator;
 using GagSpeak.State.Caches;
 using GagSpeak.WebAPI;
 using GagspeakAPI.Attributes;
+using GagspeakAPI.Data;
 using GagspeakAPI.Extensions;
 using GagspeakAPI.Hub;
 using GagspeakAPI.Network;
@@ -23,13 +24,32 @@ namespace GagSpeak.Gui.MainWindow;
 
 public partial class SidePanelPair
 {
+    // The width of the character M, plus padding, for single character buttons.
+    private readonly float _emWidth = ImGui.CalcTextSize("M").X + ImGui.GetStyle().ItemInnerSpacing.X / 4;
+
     #region Gags
     private void DrawGagActions(KinksterInfoCache cache, Kinkster k, float width, string dispName)
     {
         ImGui.TextUnformatted("Gag Actions");
 
-        if (CkGuiUtils.LayerIdxCombo("##gagLayer", width, cache.GagLayer, out var newVal, 3))
-            cache.GagLayer = newVal;
+        using (ImRaii.Group())
+        {
+            CkGui.FramedIconText(FAI.LayerGroup);
+            CkGui.TextFrameAlignedInline("Layers");
+            for (var i = 0; i <= k.ActiveGags.GagSlots.GetUpperBound(0); i++)
+            {
+                ImGui.SameLine();
+                var item = k.ActiveGags.GagSlots[i];
+                using (ImRaii.PushColor(ImGuiCol.Text, ImGuiColors.ParsedPink, cache.GagLayer == i))
+                {
+                    if (CkGui.IconTextButton(GetStateIcon(item), $"{i + 1}", ImGui.GetFrameHeight() + _emWidth, true, id: "###GagLayer-" + i))
+                        cache.GagLayer = i;
+
+                    FAI GetStateIcon(ActiveGagSlot res) => res.GagItem == GagType.None ? FAI.Expand : res.Padlock == Padlocks.None ? FAI.Tshirt : FAI.Lock;
+                }
+
+            }
+        }
         CkGui.AttachTooltip("Select the layer to apply a Gag to.");
 
         if (k.ActiveGags.GagSlots[cache.GagLayer] is not { } slot)
@@ -132,8 +152,28 @@ public partial class SidePanelPair
         ImGui.TextUnformatted("Restriction Actions");
 
         // Drawing out restriction layers.
-        if (CkGuiUtils.LayerIdxCombo("##restrictionLayer", width, cache.RestrictionLayer, out var newVal, 5))
-            cache.RestrictionLayer = newVal;
+        using (ImRaii.Group())
+        {
+            // Drawing out restriction layers.
+            CkGui.FramedIconText(FAI.LayerGroup);
+            CkGui.TextFrameAlignedInline("Layers");
+            for (var i = 0; i <= k.ActiveRestrictions.Restrictions.GetUpperBound(0); i++)
+            {
+                ImGui.SameLine();
+                var res = k.ActiveRestrictions.Restrictions[i];
+                //CkGui.IconTextAligned(GetStateIcon(res), GetLayerColor(i));
+                using (ImRaii.PushColor(ImGuiCol.Text, ImGuiColors.ParsedPink, cache.RestrictionLayer == i))
+                {
+                    if (CkGui.IconTextButton(GetStateIcon(res), $"{i + 1}", ImGui.GetFrameHeight() + _emWidth, true, id: "###RestrictionLayer-" + i))
+                    {
+                        cache.RestrictionLayer = i;
+                    }
+
+                    FAI GetStateIcon(ActiveRestriction r) => r.Identifier == Guid.Empty ? FAI.Expand : res.Padlock == Padlocks.None ? FAI.Tshirt : FAI.Lock;
+                }
+            }
+        }
+
         CkGui.AttachTooltip("Select the layer to apply a Restriction to.");
 
         if (k.ActiveRestrictions.Restrictions[cache.RestrictionLayer] is not { } slot)


### PR DESCRIPTION
This is my proposal for swapping the layer selection drop downs in the interactions UI with buttons that show extremely basic state information, and the currently selected layer using a different colour (room for improvement here)

Icon Meaning... I chose these to be hopefully intuitive, but that's just my vibes, so these can be easily changed as well.
 🔳=Slot is empty.
 👕=Item is set in this slot.
 🔒=Slot's item is locked.
 
The button that is lit pink is the currently selected layer. There's some room for improvement here too for acessiblity reasons.

(edit, adding further context) I developed this because of the multiple times items have been placed on me and later forgotten, and other users raising to my attention that they found it difficult to keep track of the layers on others.

Preview image of what this results in.
<img width="435" height="561" alt="image" src="https://github.com/user-attachments/assets/8c03563f-29e8-44b2-b95d-89d9023701d9" />

