### PR TITLE
Cursed bug fixes

### DIFF
--- a/ProjectGagSpeak/FileSystems/Selectors/CursedLootFileSelector.cs
+++ b/ProjectGagSpeak/FileSystems/Selectors/CursedLootFileSelector.cs
@@ -65,7 +65,10 @@ public sealed class CursedLootFileSelector : CkFileSystemSelector<CursedItem, Cu
 
     private void PoolOptions(CursedLootFileSystem.Leaf leaf)
     {
-        if (ImGui.MenuItem($"{(leaf.Value.InPool ? "Remove item from" : "Add item to")} the Loot Pool"))
+        var leafText = $"{(leaf.Value.InPool ? "Remove item from" : "Add item to")} the Loot Pool";
+        if (leaf.Value.IsActive()) leafText = "Item is currently active";
+
+        if (ImGui.MenuItem(leafText, false, !leaf.Value.IsActive()))
         {
             _manager.TogglePoolState(leaf.Value);
             ImGui.CloseCurrentPopup();

--- a/ProjectGagSpeak/State/Managers/CacheManagers/CacheStateManager.cs
+++ b/ProjectGagSpeak/State/Managers/CacheManagers/CacheStateManager.cs
@@ -146,8 +146,9 @@ public class CacheStateManager : IHostedService
         _logger.LogInformation("------ Gag Data synced to Cache ------ ");
 
         // Sync all server restriction data with the RestrictionManager.
-        var validCursedItems = _cursedItems.Storage.ActiveAppliedLoot.OfType<CursedRestrictionItem>().Where(i => i.RefItem != null).ToList();
-        _restrictions.LoadInternalData(connectionDto.RestrictionsData, validCursedItems);
+        // I decided to put things in a dictionary so I can check the actual cursed item for the apply traits later. Alternative would have been to modify the RestrictionManager instead
+        var validCursedItems = _cursedItems.Storage.ActiveAppliedLoot.OfType<CursedRestrictionItem>().Where(i => i.RefItem != null).Select(i => (i.Identifier, i)).ToDictionary();
+        _restrictions.LoadInternalData(connectionDto.RestrictionsData, [.. validCursedItems.Values]);
         _logger.LogInformation("------ Syncing Restriction Data to Cache ------");
         foreach (var (layer, item) in _restrictions.ActiveItems)
         {
@@ -222,7 +223,7 @@ public class CacheStateManager : IHostedService
 
         // maybe sync cursed items here, OR we can just do it in conjunction with the other restriction items, i dont freaking know anymore.
         _logger.LogInformation("------ Syncing Cursed Item Restrictions to Cache ------");
-        foreach (var item in _restrictions.LootItems.Values)
+        foreach (var (cursedId, item) in _restrictions.LootItems)
         {
             if (!_restrictions.IdToLayerMap.TryGetValue(item.Identifier, out int layer))
             {
@@ -242,7 +243,9 @@ public class CacheStateManager : IHostedService
             _glamourHandler.TryAddMetaToCache(key, metaStruct);
             _modHandler.TryAddModToCache(key, item.Mod);
             _lociHandler.TryAddLociItemToCache(key, item.LociData);
-            _traitsHandler.TryAddTraitsToCache(key, item.Traits & ~(Traits.Immobile | Traits.Weighty));
+            // We have to check if the item we are about to apply traits for actually has the ApplyTraits flag set.
+            if (_config.Current.CursedItemsApplyTraits && validCursedItems[cursedId].ApplyTraits)
+                _traitsHandler.TryAddTraitsToCache(key, item.Traits & ~(Traits.Immobile | Traits.Weighty));
             _arousalHandler.TryAddArousalToCache(key, item.Arousal);
             // Conditional Additions.
             if (item is BlindfoldRestriction bfr) _overlayHandler.TryAddBlindfoldToCache(key, bfr.Properties);


### PR DESCRIPTION
This pr fixes the following issues with cursed loot:

- Right clicking cursed loot in the editor tab, allowed you to remove locked loot from the cursed loot pool.
- After logging in, cursed loot always applied hardcore traits regardless of the applyTraits flag or the setting in the settings menu.