### PR TITLE
fix: achievement tracking for dye-related achievements

### DIFF
--- a/ProjectGagSpeak/State/Managers/RestraintManager.cs
+++ b/ProjectGagSpeak/State/Managers/RestraintManager.cs
@@ -143,6 +143,7 @@ public sealed class RestraintManager : IHybridSavable
             // _managerCache.UpdateCache(AppliedRestraint);
             _mediator.Publish(new ConfigRestraintSetChanged(StorageChangeType.Modified, sourceItem));
             _saver.Save(this);
+            GagspeakEventManager.AchievementEvent(UnlocksEvent.RestraintUpdated, sourceItem);
         }
     }
 


### PR DESCRIPTION
Added the call to fire the RestraintUpdated event to ensure any achievement that is listening for that, will actually be tracked.