### PR TITLE
fix: misleading achievement timer in hardcore catagory

### DIFF
--- a/ProjectGagSpeak/PlayerClient/Achievements/Data/TimeRequiredConditionalAchievement.cs
+++ b/ProjectGagSpeak/PlayerClient/Achievements/Data/TimeRequiredConditionalAchievement.cs
@@ -87,12 +87,11 @@ public class TimeRequiredConditionalAchievement : AchievementBase
         if (IsCompleted || !MainHub.IsConnected)
             return;
 
-        if (RequiredCondition())
+        if (TaskStarted && ((DateTime.UtcNow - StartPoint) + TimeSpan.FromSeconds(10)) >= MilestoneDuration)
         {
-            if (TaskStarted && ((DateTime.UtcNow - StartPoint) + TimeSpan.FromSeconds(10)) >= MilestoneDuration)
-                CompleteTask();
+            CompleteTask();
         }
-        else
+        else if (!RequiredCondition())
         {
             GagspeakEventManager.UnlocksLogger.LogTrace($"Condition for {Title} not met. Resetting the timer.", LoggerType.AchievementInfo);
             ResetTask();
@@ -143,8 +142,8 @@ public class TimeRequiredConditionalAchievement : AchievementBase
             try
             {
                 await Task.Delay(MilestoneDuration, token);
-                if (!token.IsCancellationRequested && RequiredCondition())
-                    CompleteTask(); // reset if we take longer than the requirement.
+                if (!token.IsCancellationRequested)
+                    CompleteTask();
             }
             catch (TaskCanceledException)
             {

--- a/ProjectGagSpeak/PlayerClient/Achievements/Data/TimeRequiredConditionalAchievement.cs
+++ b/ProjectGagSpeak/PlayerClient/Achievements/Data/TimeRequiredConditionalAchievement.cs
@@ -142,8 +142,8 @@ public class TimeRequiredConditionalAchievement : AchievementBase
             try
             {
                 await Task.Delay(MilestoneDuration, token);
-                if (!token.IsCancellationRequested)
-                    CompleteTask();
+                if (!token.IsCancellationRequested && RequiredCondition())
+                    CompleteTask(); // reset if we take longer than the requirement.
             }
             catch (TaskCanceledException)
             {


### PR DESCRIPTION
fix: complete timer when duration elapses regardless of condition state
fix: elapsed-time check gates completion first; condition-false only resets when time hasn't elapsed yet.

Condition becoming false at exactly the milestone duration caused the achievement to reset instead of complete — both the Task.Delay callback and CheckCompletion() checked RequiredCondition() after time elapsed, so expiry events that invalidated the condition would race and win.

I'm not exactly sure if this is the intended behavior for this achievement type category, if it isn't let me know.

It has been tested and does fix the issue where if you lose connection/log off in the middle of it you fail the achievement. It now actually unlocks correctly.