### PR TITLE
Add start condition for timed achievements

### DIFF
--- a/ProjectGagSpeak/PlayerClient/Achievements/ClientAchievements.cs
+++ b/ProjectGagSpeak/PlayerClient/Achievements/ClientAchievements.cs
@@ -155,8 +155,8 @@ public class ClientAchievements
     public void AddRequiredTimeConditional(AchievementModuleKind module, AchievementInfo info, TimeSpan duration, Func<bool> cond, DurationTimeUnit timeUnit, Action<int, string> onCompleted, string suffix = "", string prefix = "", bool isSecret = false)
         => _saveData.Add(info.Id, new TimeRequiredConditionalAchievement(module, info, duration, cond, onCompleted, timeUnit, prefix, suffix, isSecret));
 
-    public void AddTimeLimitedConditional(AchievementModuleKind module, AchievementInfo info, TimeSpan dur, Func<bool> cond, DurationTimeUnit timeUnit, Action<int, string> onCompleted, string suffix = "", string prefix = "", bool isSecret = false)
-        => _saveData.Add(info.Id, new TimeLimitConditionalAchievement(module, info, dur, cond, onCompleted, timeUnit, prefix, suffix, isSecret));
+    public void AddTimeLimitedConditional(AchievementModuleKind module, AchievementInfo info, TimeSpan dur, Func<bool> startCond, Func<bool> cond, DurationTimeUnit timeUnit, Action<int, string> onCompleted, string suffix = "", string prefix = "", bool isSecret = false)
+        => _saveData.Add(info.Id, new TimeLimitConditionalAchievement(module, info, dur, startCond, cond, onCompleted, timeUnit, prefix, suffix, isSecret));
 
     public void AddConditionalProgress(AchievementModuleKind module, AchievementInfo info, int goal, Func<bool> cond, Action<int, string> onCompleted, string suffix = "", string prefix = "", bool reqBeginAndFinish = true, bool isSecret = false)
         => _saveData.Add(info.Id, new ConditionalProgressAchievement(module, info, goal, cond, onCompleted, reqBeginAndFinish, prefix, suffix, isSecret));

--- a/ProjectGagSpeak/PlayerClient/Achievements/Data/TimeLimitConditionalAchievement.cs
+++ b/ProjectGagSpeak/PlayerClient/Achievements/Data/TimeLimitConditionalAchievement.cs
@@ -6,17 +6,19 @@ public class TimeLimitConditionalAchievement : AchievementBase
 {
     private readonly TimeSpan MilestoneDuration;
     public DateTime StartPoint { get; set; } = DateTime.MinValue;
+    public Func<bool> RequiredStartCondition;
     public Func<bool> RequiredCondition;
     public DurationTimeUnit TimeUnit { get; init; }
     private CancellationTokenSource _cancellationTokenSource;
     private bool TaskStarted = false;
 
 
-    public TimeLimitConditionalAchievement(AchievementModuleKind module, AchievementInfo infoBase, TimeSpan duration, Func<bool> condition, 
+    public TimeLimitConditionalAchievement(AchievementModuleKind module, AchievementInfo infoBase, TimeSpan duration, Func<bool> startCondition, Func<bool> condition, 
         Action<int, string> onCompleted, DurationTimeUnit unit, string prefix = "", string suffix = "", bool isSecret = false) 
         : base(module, infoBase, ConvertToUnit(duration, unit), prefix, suffix, onCompleted, isSecret)
     {
         MilestoneDuration = duration;
+        RequiredStartCondition = startCondition;
         RequiredCondition = condition;
         TimeUnit = unit;
     }
@@ -112,7 +114,7 @@ public class TimeLimitConditionalAchievement : AchievementBase
         if (IsCompleted || !MainHub.IsConnected || TaskStarted)
             return;
 
-        if (RequiredCondition())
+        if (RequiredStartCondition())
         {
             GagspeakEventManager.UnlocksLogger.LogTrace($"Condition for {Title} met. Starting the timer.", LoggerType.AchievementInfo);
             StartPoint = DateTime.UtcNow;

--- a/ProjectGagSpeak/Services/AchievementsService.cs
+++ b/ProjectGagSpeak/Services/AchievementsService.cs
@@ -368,7 +368,7 @@ public class AchievementsService : DisposableMediatorSubscriberBase, IHostedServ
 
         // Bondodge - Within 2 seconds of having a restraint set applied to you, remove it from yourself (might want to add a duration conditional but idk?)
         _saveData.AddTimeLimitedConditional(AchievementModuleKind.Wardrobe, Achievements.Bondodge,
-            TimeSpan.FromSeconds(2), () => _restraints.AppliedRestraint is not null, DurationTimeUnit.Seconds, (id, name) => OnCompletion(id, name).ConfigureAwait(false));
+            TimeSpan.FromSeconds(2), () => _restraints.AppliedRestraint is not null, () => _restraints.AppliedRestraint is null, DurationTimeUnit.Seconds, (id, name) => OnCompletion(id, name).ConfigureAwait(false));
 
         #endregion WARDROBE MODULE
 


### PR DESCRIPTION
Updated `TimeLimitConditionalAchievement` to support start conditions, ensuring proper behavior for timed achievements. Adjusted `AddTimeLimitedConditional` and integrated changes into `AchievementsService`.

This fixes the only achievement that uses this type. I think this should be replicated to the other achievement types to allow different start and completion conditions but that can be done at a later time.