### PR TITLE
fix: Migrate PiShock integration to the new REST API

### DIFF
--- a/ProjectGagSpeak/PlayerClient/Storages/GagspeakConfig.cs
+++ b/ProjectGagSpeak/PlayerClient/Storages/GagspeakConfig.cs
@@ -74,9 +74,10 @@ public class GagspeakConfig
     public string IntifaceConnectionSocket { get; set; } = "ws://localhost:12345"; // connection link from plugin to intiface
 
     // GLOBAL HARDCORE SETTINGS. (maybe make it its own file if it gets too rediculous but yeah.
-    public string PiShockApiKey { get; set; } = ""; // PiShock Settings.
-    public string PiShockUsername { get; set; } = ""; // PiShock Settings.
-    public int PiShockMaxDuration { get; set; } = 15; // Max duration in seconds sent to Kinksters as their allowed limit.
+    public string PiShockApiKey { get; set; } = "";
+    public string PiShockUsername { get; set; } = "";
+    public int GlobalShockerId { get; set; } = 0;
+    public Dictionary<string, int> PairShockerIds { get; set; } = new(); // Per-pair shocker device selection (UID → shocker ID).
     public bool MoveToChambersInEstates { get; set; } = false; // Move to Chambers in Estates during ForcedStay
 
     public float OverlayMaxOpacity { get; set; } = 1.0f; // Blindfold Opacity

--- a/ProjectGagSpeak/PlayerClient/Storages/GagspeakConfig.cs
+++ b/ProjectGagSpeak/PlayerClient/Storages/GagspeakConfig.cs
@@ -76,6 +76,7 @@ public class GagspeakConfig
     // GLOBAL HARDCORE SETTINGS. (maybe make it its own file if it gets too rediculous but yeah.
     public string PiShockApiKey { get; set; } = ""; // PiShock Settings.
     public string PiShockUsername { get; set; } = ""; // PiShock Settings.
+    public int PiShockMaxDuration { get; set; } = 15; // Max duration in seconds sent to Kinksters as their allowed limit.
     public bool MoveToChambersInEstates { get; set; } = false; // Move to Chambers in Estates during ForcedStay
 
     public float OverlayMaxOpacity { get; set; } = 1.0f; // Blindfold Opacity

--- a/ProjectGagSpeak/PlayerKinkster/Kinkster.cs
+++ b/ProjectGagSpeak/PlayerKinkster/Kinkster.cs
@@ -91,7 +91,7 @@ public class Kinkster : IComparable<Kinkster>
     public bool IsTargetable => IsRendered ? _player.DataState.GetIsTargetable() : false;
 
     // Additional Information.
-    public bool HasShockCollar => PairGlobals.HasValidShareCode() || PairPerms.HasValidShareCode();
+    public bool HasShockCollar => PairPerms.HasValidShareCode();
 
     // Definitely change how this information is stored, possibly do so within some internal kinkplate cache or whatever.
     // It would need to hold an updated mini-cache of what we hold for the client themselves whenever a change to

--- a/ProjectGagSpeak/Triggers/ReactionDistributor.cs
+++ b/ProjectGagSpeak/Triggers/ReactionDistributor.cs
@@ -24,6 +24,7 @@ public class ReactionDistributor
 {
     private readonly ILogger<ReactionDistributor> _logger;
     private readonly PiShockProvider _shockies;
+    private readonly MainConfig _mainConfig;
     private readonly GagRestrictionManager _gags;
     private readonly RestrictionManager _restrictions;
     private readonly RestraintManager _restraints;
@@ -35,6 +36,7 @@ public class ReactionDistributor
     public ReactionDistributor(
         ILogger<ReactionDistributor> logger,
         PiShockProvider shockies,
+        MainConfig mainConfig,
         GagRestrictionManager gags,
         RestrictionManager restrictions,
         RestraintManager restraints,
@@ -45,6 +47,7 @@ public class ReactionDistributor
     {
         _logger = logger;
         _shockies = shockies;
+        _mainConfig = mainConfig;
         _gags = gags;
         _restrictions = restrictions;
         _restraints = restraints;
@@ -440,19 +443,19 @@ public class ReactionDistributor
 
     private bool PiShockReaction(PiShockAction act, string? enactor = null)
     {
-        if (ClientData.Globals is not { } perms)
+        if (ClientData.Globals is null)
             return false;
 
-        if(string.IsNullOrWhiteSpace(perms.GlobalShockShareCode) || !perms.HasValidShareCode())
+        var shockerId = _mainConfig.Current.GlobalShockerId;
+        if (shockerId == 0)
         {
-            _logger.LogWarning("Can't execute Shock Instruction if none are currently connected!");
+            _logger.LogWarning("Can't execute Shock Instruction if no shocker is selected!");
             return false;
         }
 
-        // execute the instruction with our global share code.
-        _logger.LogInformation("DoPiShock Action is executing instruction based on global sharecode settings!", LoggerType.PiShock);
-        var shareCode = perms.GlobalShockShareCode;
-        _shockies.ExecuteOperation(shareCode, (int)act.ShockInstruction.OpCode, act.ShockInstruction.Intensity, act.ShockInstruction.Duration);
+        _logger.LogInformation("DoPiShock Action is executing instruction based on global shocker settings!", LoggerType.PiShock);
+        var durationMs = (int)(act.ShockInstruction.GetDurationFloat() * 1000f);
+        _shockies.ExecuteOperation(shockerId, (int)act.ShockInstruction.OpCode, act.ShockInstruction.Intensity, durationMs);
         return true;
     }
 

--- a/ProjectGagSpeak/UI/Components/Drawers/ReactionsDrawer.cs
+++ b/ProjectGagSpeak/UI/Components/Drawers/ReactionsDrawer.cs
@@ -11,6 +11,7 @@ using GagSpeak.CustomCombos.Editor;
 using GagSpeak.Interop.Helpers;
 using GagSpeak.PlayerClient;
 using GagSpeak.Services.Mediator;
+using GagSpeak.WebAPI;
 using GagSpeak.Services.Textures;
 using GagSpeak.State.Caches;
 using GagSpeak.State.Managers;
@@ -936,7 +937,7 @@ public sealed class ReactionsDrawer
         var dur = act.ShockInstruction.GetDurationFloat();
         ImUtf8.SameLineInner();
         ImGui.SetNextItemWidth(ImGui.GetContentRegionAvail().X);
-        if (ImGui.SliderFloat("##Duration", ref dur, 0.016f, 15f, "%.3fs"))
+        if (ImGui.SliderFloat("##Duration", ref dur, 0.3f, 15f, "%.3fs"))
             act.ShockInstruction.SetDuration(dur);
 
         if (act.ShockInstruction.OpCode is not ShockMode.Beep)
@@ -965,7 +966,7 @@ public sealed class ReactionsDrawer
         var durationRef = action.ShockInstruction.GetDurationFloat();
         ImUtf8.SameLineInner();
         ImGui.SetNextItemWidth(85f);
-        if (ImGui.SliderFloat("##ShockDur", ref durationRef, 0.016f, 15f))
+        if (ImGui.SliderFloat("##ShockDur", ref durationRef, 0.3f, 15f))
             action.ShockInstruction.SetDuration(durationRef);
         CkGui.AttachTooltip("The duration of the instruction.");
 

--- a/ProjectGagSpeak/UI/MainUi/SidePanel/SidePanelKinkster/SidePanelPair.Interactions.cs
+++ b/ProjectGagSpeak/UI/MainUi/SidePanel/SidePanelKinkster/SidePanelPair.Interactions.cs
@@ -599,20 +599,12 @@ public partial class SidePanelPair
             canShock = k.PairPerms.AllowShocks;
             canVibrate = k.PairPerms.AllowVibrations;
             canBeep = k.PairPerms.AllowBeeps;
-            maxDuration = k.PairPerms.MaxDuration;
+            maxDuration = (float)k.PairPerms.GetTimespanFromDuration().TotalSeconds;
             maxIntensity = k.PairPerms.MaxIntensity;
-        }
-        else if (k.PairGlobals.HasValidShareCode())
-        {
-            canShock = k.PairGlobals.AllowShocks;
-            canVibrate = k.PairGlobals.AllowVibrations;
-            canBeep = k.PairGlobals.AllowBeeps;
-            maxDuration = k.PairGlobals.MaxDuration;
-            maxIntensity = k.PairGlobals.MaxIntensity;
         }
         else
         {
-            ImGui.TextUnformatted("Not permitted to use.");
+            CkGui.ColorTextCentered("No PiShock configured or online.", ImGuiColors.DalamudGrey);
             return;
         }
 
@@ -626,7 +618,7 @@ public partial class SidePanelPair
         if (shockerIntensity < 1) shockerIntensity = 1;
         else if (shockerIntensity > maxIntensity) shockerIntensity = maxIntensity;
 
-        var shockerDurationSeconds = (int)(shockerDuration * 1000f);
+        var durationMs = (int)(shockerDuration * 1000f);
 
         ImGui.SetNextItemWidth(120 * ImGuiHelpers.GlobalScale);
         ImGui.SliderInt("Intensity", ref shockerIntensity, 1, maxIntensity, "%d%%");
@@ -639,7 +631,7 @@ public partial class SidePanelPair
         {
             UiService.SetUITask(async () =>
             {
-                var res = await _hub.UserShockKinkster(new(k.UserData, 0 /* shock */, shockerIntensity, shockerDurationSeconds));
+                var res = await _hub.UserShockKinkster(new(k.UserData, 0 /* shock */, shockerIntensity, durationMs));
                 if (res.ErrorCode is not GagSpeakApiEc.Success)
                     _logger.LogError($"Failed to shock {dispName}. ({res.ErrorCode})", LoggerType.StickyUI);
             });
@@ -650,7 +642,7 @@ public partial class SidePanelPair
         {
             UiService.SetUITask(async () =>
             {
-                var res = await _hub.UserShockKinkster(new(k.UserData, 2 /* beep */, shockerIntensity, shockerDurationSeconds));
+                var res = await _hub.UserShockKinkster(new(k.UserData, 2 /* beep */, shockerIntensity, durationMs));
                 if (res.ErrorCode is not GagSpeakApiEc.Success)
                     _logger.LogError($"Failed to beep {dispName}. ({res.ErrorCode})", LoggerType.StickyUI);
             });
@@ -661,7 +653,7 @@ public partial class SidePanelPair
         {
             UiService.SetUITask(async () =>
             {
-                var res = await _hub.UserShockKinkster(new(k.UserData, 1 /* vibrate */, shockerIntensity, shockerDurationSeconds));
+                var res = await _hub.UserShockKinkster(new(k.UserData, 1 /* vibrate */, shockerIntensity, durationMs));
                 if (res.ErrorCode is not GagSpeakApiEc.Success)
                     _logger.LogError($"Failed to vibrate {dispName}. ({res.ErrorCode})", LoggerType.StickyUI);
             });

--- a/ProjectGagSpeak/UI/MainUi/SidePanel/SidePanelKinkster/SidePanelPair.Shockies.cs
+++ b/ProjectGagSpeak/UI/MainUi/SidePanel/SidePanelKinkster/SidePanelPair.Shockies.cs
@@ -1,5 +1,6 @@
 using CkCommons.Gui;
 using Dalamud.Bindings.ImGui;
+using Dalamud.Interface.Colors;
 using Dalamud.Interface.Utility.Raii;
 using GagSpeak.Kinksters;
 using GagSpeak.Services;
@@ -19,41 +20,104 @@ public partial class SidePanelPair
     {
         using var _ = ImRaii.Group();
 
-        var length = width - CkGui.IconTextButtonSize(FAI.Sync, "Refresh") + ImGui.GetFrameHeight();
         var refCode = k.OwnPerms.PiShockShareCode;
-        // the bad way.
-        CkGui.IconInputText(FAI.ShareAlt, string.Empty, "Unique Share Code", ref refCode, 40, width, true, false);
+        var refreshWidth = CkGui.IconTextButtonSize(FAI.Sync, "Refresh");
+        ImGui.SetNextItemWidth(width - refreshWidth - ImGui.GetStyle().ItemInnerSpacing.X);
+        CkGui.IconInputText(FAI.ShareAlt, string.Empty, "Unique Share Code", ref refCode, 40, width - refreshWidth - ImGui.GetStyle().ItemInnerSpacing.X, true, false);
         if (ImGui.IsItemDeactivatedAfterEdit())
         {
-            // No action if the code is the same.
             if (refCode == k.OwnPerms.PiShockShareCode)
                 return;
 
             UiService.SetUITask(async () =>
             {
                 if (await PermHelper.ChangeOwnUnique(_hub, k.UserData, k.OwnPerms, nameof(PairPerms.PiShockShareCode), refCode))
-                    await SyncPermissionsWithCode(refCode, k);
+                    await SyncAllPairsAsync(k, refCode);
             });
         }
         CkGui.AttachTooltip($"Unique Share Code for --COL--{dispName}--COL--." +
-            $"--NL--Permissions here are prioritized over --COL--Global Share Code--COL--, unique to {dispName}.");
+            $"--NL--This code gives {dispName} permission to interact with your PiShock device.");
 
         ImUtf8.SameLineInner();
         if (CkGui.IconTextButton(FAI.Sync, "Refresh", disabled: string.IsNullOrEmpty(refCode) || UiService.DisableUI))
-            UiService.SetUITask(async () => await SyncPermissionsWithCode(k.OwnPerms.PiShockShareCode, k));
+            UiService.SetUITask(async () => await SyncAllPairsAsync(k, k.OwnPerms.PiShockShareCode));
+        CkGui.AttachTooltip("Refresh permissions for all pairs with a share code set.");
+
+        if (_shockies.LastConnectState is not PiShockProvider.ConnectState.Success)
+        {
+            CkGui.ColorText("Not connected - click Save & Connect in Settings first.", ImGuiColors.DalamudRed);
+            return;
+        }
+
+        if (!string.IsNullOrEmpty(refCode))
+        {
+            if (k.OwnPerms.MaxDuration <= 0)
+            {
+                CkGui.ColorText("Not synced - click Refresh", ImGuiColors.DalamudYellow);
+            }
+            else
+            {
+                var maxSecs = (float)k.OwnPerms.GetTimespanFromDuration().TotalSeconds;
+                var shock = k.OwnPerms.AllowShocks;
+                var vibe  = k.OwnPerms.AllowVibrations;
+                var beep  = k.OwnPerms.AllowBeeps;
+
+                CkGui.ColorText("Shock: ", ImGuiColors.DalamudGrey);
+                ImGui.SameLine(0, 2);
+                CkGui.ColorText(shock ? "Yes" : "No", shock ? ImGuiColors.HealerGreen : ImGuiColors.DalamudRed);
+                ImGui.SameLine(0, 8);
+                CkGui.ColorText("Vibrate: ", ImGuiColors.DalamudGrey);
+                ImGui.SameLine(0, 2);
+                CkGui.ColorText(vibe ? "Yes" : "No", vibe ? ImGuiColors.HealerGreen : ImGuiColors.DalamudRed);
+                ImGui.SameLine(0, 8);
+                CkGui.ColorText("Beep: ", ImGuiColors.DalamudGrey);
+                ImGui.SameLine(0, 2);
+                CkGui.ColorText(beep ? "Yes" : "No", beep ? ImGuiColors.HealerGreen : ImGuiColors.DalamudRed);
+
+                CkGui.ColorText($"Max Intensity: {k.OwnPerms.MaxIntensity}%  |  Max Duration: {maxSecs:0.#}s", ImGuiColors.DalamudGrey);
+            }
+        }
+
+        var shockers = _shockies.CachedShockers;
+        if (shockers.Count > 0)
+        {
+            ImGui.Spacing();
+            var currentId = _shockies.GetPairShockerId(k.UserData.UID);
+            var currentName = shockers.FirstOrDefault(s => s.Id == currentId).Name ?? "Select Device...";
+
+            ImGui.SetNextItemWidth(width);
+            using (var combo = ImRaii.Combo("##Dev_" + k.UserData.UID, currentName))
+            {
+                if (combo)
+                {
+                    foreach (var (id, name) in shockers)
+                    {
+                        if (ImGui.Selectable(name, id == currentId))
+                            _shockies.SetPairShockerId(k.UserData.UID, id);
+                    }
+                }
+            }
+            CkGui.AttachTooltip($"Choose which PiShock device {dispName} controls.");
+        }
     }
 
     public void DrawShockActions(KinksterInfoCache cache, Kinkster k, string dispName, float width)
     {
         ImGui.TextUnformatted("Shock Collar Actions");
-        var preferPairCode = k.PairPerms.HasValidShareCode();
-        var maxDuration = preferPairCode ? k.PairPerms.GetTimespanFromDuration() : k.PairGlobals.GetTimespanFromDuration();
+
+        if (!k.PairPerms.HasValidShareCode())
+        {
+            CkGui.ColorText("No PiShock configured or online.", ImGuiColors.DalamudGrey);
+            return;
+        }
+
+        var maxDuration = k.PairPerms.GetTimespanFromDuration();
         var maxSecs = (float)maxDuration.TotalSeconds;
         cache.ApplyDuration = Math.Clamp(cache.ApplyDuration, 0.1f, maxSecs);
         cache.ApplyVibeDur = Math.Clamp(cache.ApplyVibeDur, 0.0f, maxSecs);
 
         // Shock Expander
-        var AllowShocks = preferPairCode ? k.PairPerms.AllowShocks : k.PairGlobals.AllowShocks;
+        var AllowShocks = k.PairPerms.AllowShocks;
         if (CkGui.IconTextButton(FAI.BoltLightning, $"Shock {dispName}'s Shock Collar", width, true, !AllowShocks))
             cache.ToggleInteraction(InteractionType.ShockAction);
         CkGui.AttachTooltip($"Perform a Shock action to {dispName}'s Shock Collar.");
@@ -61,12 +125,12 @@ public partial class SidePanelPair
         if (cache.OpenItem is InteractionType.ShockAction)
         {
             using (ImRaii.Child("SCA_Child", new Vector2(width, ImGui.GetFrameHeight() * 2 + ImGui.GetStyle().ItemSpacing.Y)))
-                ShockAct(cache, k, dispName, width, preferPairCode, maxDuration);
+                ShockAct(cache, k, dispName, width, maxDuration);
             ImGui.Separator();
         }
 
         // Vibrate Expander
-        var AllowVibrations = preferPairCode ? k.PairPerms.AllowVibrations : k.PairGlobals.AllowVibrations;
+        var AllowVibrations = k.PairPerms.AllowVibrations;
         if (CkGui.IconTextButton(FAI.WaveSquare, $"Vibrate {dispName}'s Shock Collar", width, true, !AllowVibrations))
             cache.ToggleInteraction(InteractionType.VibrateAction);
         CkGui.AttachTooltip($"Perform a Vibrate action to {dispName}'s Shock Collar.");
@@ -74,13 +138,12 @@ public partial class SidePanelPair
         if (cache.OpenItem is InteractionType.VibrateAction)
         {
             using (ImRaii.Child("VCA_Child", new Vector2(width, ImGui.GetFrameHeight() * 2 + ImGui.GetStyle().ItemSpacing.Y)))
-                VibeAct(cache, k, dispName, width, preferPairCode, maxDuration);
+                VibeAct(cache, k, dispName, width, maxDuration);
             ImGui.Separator();
         }
 
-
         // Beep Expander
-        var AllowBeeps = preferPairCode ? k.PairPerms.AllowBeeps : k.PairGlobals.AllowBeeps;
+        var AllowBeeps = k.PairPerms.AllowBeeps;
         if (CkGui.IconTextButton(FAI.LandMineOn, $"Beep {dispName}'s Shock Collar", width, true, !AllowBeeps))
             cache.ToggleInteraction(InteractionType.BeepAction);
         CkGui.AttachTooltip($"Beep {dispName}'s Shock Collar");
@@ -88,8 +151,20 @@ public partial class SidePanelPair
         if (cache.OpenItem is InteractionType.BeepAction)
         {
             using (ImRaii.Child("BCA_Child", new Vector2(width, ImGui.GetFrameHeight())))
-                BeepAct(cache, k, dispName, width, preferPairCode, maxDuration);
+                BeepAct(cache, k, dispName, width, maxDuration);
             ImGui.Separator();
+        }
+    }
+
+    private async Task SyncAllPairsAsync(Kinkster currentK, string codeForCurrent)
+    {
+        await SyncPermissionsWithCode(codeForCurrent, currentK);
+        foreach (var k in _kinksters.DirectPairs)
+        {
+            if (k.UserData.UID == currentK.UserData.UID) continue;
+            var code = k.OwnPerms.PiShockShareCode;
+            if (!string.IsNullOrEmpty(code))
+                await SyncPermissionsWithCode(code, k);
         }
     }
 
@@ -105,13 +180,12 @@ public partial class SidePanelPair
             MaxDuration = newShockPerms.MaxDuration,
             MaxIntensity = newShockPerms.MaxIntensity
         };
-        // push update
         await _hub.UserBulkChangeUnique(new(k.UserData, newPerms, k.OwnPermAccess, UpdateDir.Own, MainHub.OwnUserData));
     }
 
-    private void ShockAct(KinksterInfoCache cache, Kinkster k, string dispName, float width, bool usePairCode, TimeSpan maxDuration)
+    private void ShockAct(KinksterInfoCache cache, Kinkster k, string dispName, float width, TimeSpan maxDuration)
     {
-        var maxIntensity = usePairCode ? k.PairPerms.MaxIntensity : k.PairGlobals.MaxIntensity;
+        var maxIntensity = k.PairPerms.MaxIntensity;
         ImGui.SetNextItemWidth(width);
         ImGui.SliderInt($"##SCI-{k.UserData.UID}", ref cache.ApplyIntensity, 0, maxIntensity, " % d%%", ImGuiSliderFlags.None);
 
@@ -137,7 +211,7 @@ public partial class SidePanelPair
         }
     }
 
-    private void VibeAct(KinksterInfoCache cache, Kinkster k, string dispName, float width, bool usePairCode, TimeSpan maxDuration)
+    private void VibeAct(KinksterInfoCache cache, Kinkster k, string dispName, float width, TimeSpan maxDuration)
     {
         ImGui.SetNextItemWidth(width);
         ImGui.SliderInt($"##ISR-{k.UserData.UID}", ref cache.ApplyVibeIntensity, 0, 100, "%d%%", ImGuiSliderFlags.None);
@@ -161,7 +235,7 @@ public partial class SidePanelPair
         }
     }
 
-    private void BeepAct(KinksterInfoCache cache, Kinkster k, string dispName, float width, bool usePairCode, TimeSpan maxDuration)
+    private void BeepAct(KinksterInfoCache cache, Kinkster k, string dispName, float width, TimeSpan maxDuration)
     {
         var max = (float)maxDuration.TotalSeconds;
         ImGui.SetNextItemWidth(width - CkGui.IconTextButtonSize(FAI.LandMineOn, "Beep") - ImGui.GetStyle().ItemInnerSpacing.X);
@@ -174,7 +248,7 @@ public partial class SidePanelPair
             _logger.LogDebug($"Sending Beep for: {durationMs}ms");
             UiService.SetUITask(async () =>
             {
-                var res = await _hub.UserShockKinkster(new ShockCollarAction(k.UserData, 2, cache.ApplyIntensity, durationMs));
+                var res = await _hub.UserShockKinkster(new ShockCollarAction(k.UserData, 2, 0, durationMs));
                 if (res.ErrorCode is not GagSpeakApiEc.Success)
                     _logger.LogDebug($"Failed to send Beep to {dispName}'s Shock Collar. ({res})", LoggerType.StickyUI);
                 else

--- a/ProjectGagSpeak/UI/MainUi/SidePanel/SidePanelKinkster/SidePanelPair.Shockies.cs
+++ b/ProjectGagSpeak/UI/MainUi/SidePanel/SidePanelKinkster/SidePanelPair.Shockies.cs
@@ -48,6 +48,9 @@ public partial class SidePanelPair
         ImGui.TextUnformatted("Shock Collar Actions");
         var preferPairCode = k.PairPerms.HasValidShareCode();
         var maxDuration = preferPairCode ? k.PairPerms.GetTimespanFromDuration() : k.PairGlobals.GetTimespanFromDuration();
+        var maxSecs = (float)maxDuration.TotalSeconds;
+        cache.ApplyDuration = Math.Clamp(cache.ApplyDuration, 0.1f, maxSecs);
+        cache.ApplyVibeDur = Math.Clamp(cache.ApplyVibeDur, 0.0f, maxSecs);
 
         // Shock Expander
         var AllowShocks = preferPairCode ? k.PairPerms.AllowShocks : k.PairGlobals.AllowShocks;
@@ -112,24 +115,23 @@ public partial class SidePanelPair
         ImGui.SetNextItemWidth(width);
         ImGui.SliderInt($"##SCI-{k.UserData.UID}", ref cache.ApplyIntensity, 0, maxIntensity, " % d%%", ImGuiSliderFlags.None);
 
-        // ensure we cant fall below 100ms to rely on millisecond conversion.
         ImGui.SetNextItemWidth(width - CkGui.IconTextButtonSize(FAI.BoltLightning, "Shock") - ImGui.GetStyle().ItemInnerSpacing.X);
-        ImGui.SliderFloat($"##SCD-{k.UserData.UID}", ref cache.ApplyDuration, 0.1f, (float)maxDuration.TotalMilliseconds / 1000f, "%.1fs", ImGuiSliderFlags.None);
+        ImGui.SliderFloat($"##SCD-{k.UserData.UID}", ref cache.ApplyDuration, 0.1f, (float)maxDuration.TotalSeconds, "%.1fs", ImGuiSliderFlags.None);
 
         ImUtf8.SameLineInner();
-        if (CkGui.IconTextButton(FAI.BoltLightning, "Send Shock", disabled: cache.ApplyDuration <= 100))
+        if (CkGui.IconTextButton(FAI.BoltLightning, "Send Shock", disabled: cache.ApplyDuration <= 0))
         {
-            var finalVal = TimeSpan.FromMilliseconds(cache.ApplyDuration);
-            _logger.LogDebug($"Sending Shock with duration: {finalVal}ms");
+            var durationMs = (int)(cache.ApplyDuration * 1000f);
+            _logger.LogDebug($"Sending Shock with duration: {durationMs}ms");
             UiService.SetUITask(async () =>
             {
-                var res = await _hub.UserShockKinkster(new(k.UserData, 0, cache.ApplyIntensity, finalVal.Milliseconds));
+                var res = await _hub.UserShockKinkster(new(k.UserData, 0, cache.ApplyIntensity, durationMs));
                 if (res.ErrorCode is not GagSpeakApiEc.Success)
                 {
                     _logger.LogDebug($"Failed to send Shock to {dispName}'s Shock Collar. ({res})", LoggerType.StickyUI);
                     return;
                 }
-                _logger.LogDebug($"Sent Shock to {dispName}'s Shock Collar for: {finalVal}ms", LoggerType.StickyUI);
+                _logger.LogDebug($"Sent Shock to {dispName}'s Shock Collar for: {durationMs}ms", LoggerType.StickyUI);
                 GagspeakEventManager.AchievementEvent(UnlocksEvent.ShockSent);
             });
         }
@@ -140,45 +142,43 @@ public partial class SidePanelPair
         ImGui.SetNextItemWidth(width);
         ImGui.SliderInt($"##ISR-{k.UserData.UID}", ref cache.ApplyVibeIntensity, 0, 100, "%d%%", ImGuiSliderFlags.None);
 
-        // ensure we cant fall below 100ms to rely on millisecond conversion.
         ImGui.SetNextItemWidth(width - CkGui.IconTextButtonSize(FAI.HeartCircleBolt, "Vibrate") - ImGui.GetStyle().ItemInnerSpacing.X);
-        ImGui.SliderFloat($"##DSR-{k.UserData.UID}", ref cache.ApplyVibeDur, 0.0f, (float)maxDuration.TotalMilliseconds / 1000f, "%.1fs", ImGuiSliderFlags.None);
+        ImGui.SliderFloat($"##DSR-{k.UserData.UID}", ref cache.ApplyVibeDur, 0.0f, (float)maxDuration.TotalSeconds, "%.1fs", ImGuiSliderFlags.None);
 
         ImUtf8.SameLineInner();
-        if (CkGui.IconTextButton(FAI.HeartCircleBolt, "Send Vibration", disabled: cache.ApplyDuration <= 100))
+        if (CkGui.IconTextButton(FAI.HeartCircleBolt, "Send Vibration", disabled: cache.ApplyVibeDur <= 0))
         {
-            var finalVal = TimeSpan.FromMilliseconds(cache.ApplyVibeDur);
-            _logger.LogDebug($"Sending Vibration with duration: {finalVal}ms");
+            var durationMs = (int)(cache.ApplyVibeDur * 1000f);
+            _logger.LogDebug($"Sending Vibration with duration: {durationMs}ms");
             UiService.SetUITask(async () =>
             {
-                var res = await _hub.UserShockKinkster(new(k.UserData, 1, cache.ApplyVibeIntensity, finalVal.Milliseconds));
+                var res = await _hub.UserShockKinkster(new(k.UserData, 1, cache.ApplyVibeIntensity, durationMs));
                 if (res.ErrorCode is not GagSpeakApiEc.Success)
                     _logger.LogDebug($"Failed to send Vibration to {dispName}'s Shock Collar. ({res})", LoggerType.StickyUI);
                 else
-                    _logger.LogDebug($"Sent Vibration to {dispName}'s Shock Collar for: {finalVal}ms", LoggerType.StickyUI);
+                    _logger.LogDebug($"Sent Vibration to {dispName}'s Shock Collar for: {durationMs}ms", LoggerType.StickyUI);
             });
         }
     }
 
     private void BeepAct(KinksterInfoCache cache, Kinkster k, string dispName, float width, bool usePairCode, TimeSpan maxDuration)
     {
-        var max = (float)maxDuration.TotalMilliseconds / 1000f;
+        var max = (float)maxDuration.TotalSeconds;
         ImGui.SetNextItemWidth(width - CkGui.IconTextButtonSize(FAI.LandMineOn, "Beep") - ImGui.GetStyle().ItemInnerSpacing.X);
         ImGui.SliderFloat("##DurationSliderRef" + k.UserData.UID, ref cache.ApplyVibeDur, 0.1f, max, "%.1fs", ImGuiSliderFlags.None);
 
         ImUtf8.SameLineInner();
-        if (CkGui.IconTextButton(FAI.LandMineOn, "Send Beep", disabled: cache.ApplyVibeDur <= 100))
+        if (CkGui.IconTextButton(FAI.LandMineOn, "Send Beep", disabled: cache.ApplyVibeDur <= 0))
         {
-            _logger.LogDebug($"Sending Beep foir {cache.ApplyVibeDur}ms!");
+            var durationMs = (int)(cache.ApplyVibeDur * 1000f);
+            _logger.LogDebug($"Sending Beep for: {durationMs}ms");
             UiService.SetUITask(async () =>
             {
-                var finalVal = TimeSpan.FromMilliseconds(cache.ApplyVibeDur);
-                _logger.LogDebug($"Sending Beep for: {finalVal}ms");
-                var res = await _hub.UserShockKinkster(new ShockCollarAction(k.UserData, 2, cache.ApplyIntensity, finalVal.Milliseconds));
+                var res = await _hub.UserShockKinkster(new ShockCollarAction(k.UserData, 2, cache.ApplyIntensity, durationMs));
                 if (res.ErrorCode is not GagSpeakApiEc.Success)
                     _logger.LogDebug($"Failed to send Beep to {dispName}'s Shock Collar. ({res})", LoggerType.StickyUI);
                 else
-                    _logger.LogDebug($"Sent Beep to {dispName}'s Shock Collar for: {finalVal}ms", LoggerType.StickyUI);
+                    _logger.LogDebug($"Sent Beep to {dispName}'s Shock Collar for: {durationMs}ms", LoggerType.StickyUI);
             });
         }
     }

--- a/ProjectGagSpeak/UI/MainUi/SidePanel/SidePanelKinkster/SidePanelPair.cs
+++ b/ProjectGagSpeak/UI/MainUi/SidePanel/SidePanelKinkster/SidePanelPair.cs
@@ -199,8 +199,8 @@ public partial class SidePanelPair
         PanelPairEx.HardcoreConfirmationPopup(_hub, kinkster, dispName);
 
         ImGui.TextUnformatted("Shock Collar Permissions");
-        if (ClientData.Globals is not { } p || !p.HasValidShareCode())
-            CkGui.ColorTextCentered("Must have a valid Global ShareCode first!", ImGuiColors.DalamudRed);
+        if (!_shockies.IsConfigured)
+            CkGui.ColorTextCentered("PiShock not configured - set Username & API Key in Settings.", ImGuiColors.DalamudRed);
         else
         {
             UniqueShareCode(kinkster, dispName, width);

--- a/ProjectGagSpeak/UI/Settings/SettingsUi.cs
+++ b/ProjectGagSpeak/UI/Settings/SettingsUi.cs
@@ -495,12 +495,32 @@ public class SettingsUi : WindowMediatorSubscriberBase
                 break;
 
             case PiShockProvider.ConnectState.Success:
-                CkGui.ColorText($"{_shockProvider.ShockerCount} Available Shocker(s):", ImGuiColors.DalamudGrey);
-                foreach (var (_, name) in _shockProvider.CachedShockers)
-                    CkGui.ColorText($"  • {name}", ImGuiColors.HealerGreen);
+            {
+                var shockers = _shockProvider.CachedShockers;
+                CkGui.ColorText($"{shockers.Count} Shocker(s) found. Default device for triggers:", ImGuiColors.DalamudGrey);
+
+                var currentId   = _mainConfig.Current.GlobalShockerId;
+                var currentName = shockers.FirstOrDefault(s => s.Id == currentId).Name ?? "Select a device...";
+                ImGui.SetNextItemWidth(inputWidth);
+                using (var combo = ImRaii.Combo("##GlobalShocker", currentName))
+                {
+                    if (combo)
+                    {
+                        foreach (var (id, name) in shockers)
+                        {
+                            if (ImGui.Selectable(name, id == currentId))
+                            {
+                                _mainConfig.Current.GlobalShockerId = id;
+                                _mainConfig.Save();
+                            }
+                        }
+                    }
+                }
+                CkGui.AttachTooltip("The device used when a trigger fires a shock action.");
                 ImGui.Spacing();
                 CkGui.ColorText("Configure a share code in each pair's permissions.", ImGuiColors.DalamudGrey);
                 break;
+            }
         }
     }
 

--- a/ProjectGagSpeak/UI/Settings/SettingsUi.cs
+++ b/ProjectGagSpeak/UI/Settings/SettingsUi.cs
@@ -452,6 +452,7 @@ public class SettingsUi : WindowMediatorSubscriberBase
                 _mainConfig.Save();
             }
             CkGui.HelpText(GSLoc.Settings.MainOptions.PiShockKeyTT);
+            CkGui.ColorText("API keys must be generated after Oct 15, 2024. If connection fails, re-login at login.pishock.com to validate your key.", ImGuiColors.DalamudYellow);
 
             ImGui.SetNextItemWidth(250 * ImGuiHelpers.GlobalScale);
             if (ImGui.InputText("PiShock Username", ref username, 100, ImGuiInputTextFlags.EnterReturnsTrue))
@@ -461,6 +462,14 @@ public class SettingsUi : WindowMediatorSubscriberBase
             }
             CkGui.HelpText(GSLoc.Settings.MainOptions.PiShockUsernameTT);
 
+            var maxDuration = _mainConfig.Current.PiShockMaxDuration;
+            ImGui.SetNextItemWidth(250 * ImGuiHelpers.GlobalScale);
+            if (ImGui.SliderInt("Max Duration (s)##pishock", ref maxDuration, 1, 15))
+            {
+                _mainConfig.Current.PiShockMaxDuration = maxDuration;
+                _mainConfig.Save();
+            }
+            CkGui.HelpText("Maximum shock duration in seconds sent to Kinksters as your allowed limit. Click Refresh after changing.");
 
             ImGui.SetNextItemWidth(250 * ImGuiHelpers.GlobalScale - CkGui.IconTextButtonSize(FAI.Sync, "Refresh") - ImGui.GetStyle().ItemInnerSpacing.X);
             if (ImGui.InputText("##Global PiShock Share Code", ref shareCode, 100, ImGuiInputTextFlags.EnterReturnsTrue))
@@ -508,6 +517,7 @@ public class SettingsUi : WindowMediatorSubscriberBase
                 var maxGlobalShockDuration = globals.GetTimespanFromDuration();
                 CkGui.ColorTextFrameAlignedInline($"{maxGlobalShockDuration.Seconds}.{maxGlobalShockDuration.Milliseconds}s", ImGuiColors.ParsedGold);
             }
+
         }
     }
 

--- a/ProjectGagSpeak/UI/Settings/SettingsUi.cs
+++ b/ProjectGagSpeak/UI/Settings/SettingsUi.cs
@@ -8,6 +8,7 @@ using Dalamud.Interface.Utility.Raii;
 using GagSpeak.GameInternals.Agents;
 using GagSpeak.Interop;
 using GagSpeak.Interop.Helpers;
+using GagSpeak.Kinksters;
 using GagSpeak.Localization;
 using GagSpeak.PlayerClient;
 using GagSpeak.Services;
@@ -19,7 +20,9 @@ using GagSpeak.Utils;
 using GagSpeak.WebAPI;
 using GagspeakAPI.Attributes;
 using GagspeakAPI.Data.Permissions;
+using GagspeakAPI.Enums;
 using GagspeakAPI.Hub;
+using GagspeakAPI.Network;
 using OtterGui;
 using OtterGui.Text;
 
@@ -38,11 +41,12 @@ public class SettingsUi : WindowMediatorSubscriberBase
     private readonly PiShockProvider _shockProvider;
     private readonly ClientDataListener _clientDatListener;
     private readonly PluginGuideProvider _guideProvider;
+    private readonly KinksterManager _kinksters;
 
     private ProjectTabBar _myProjects;
     public SettingsUi(ILogger<SettingsUi> logger, GagspeakMediator mediator, MainHub hub,
         MainConfig config, ProfilesTab accounts, DebugTab debug, PiShockProvider shockProvider,
-        ClientDataListener listener, PluginGuideProvider guideProvider)
+        ClientDataListener listener, PluginGuideProvider guideProvider, KinksterManager kinksters)
         : base(logger, mediator, "GagSpeak Settings")
     {
         _hub = hub;
@@ -52,6 +56,7 @@ public class SettingsUi : WindowMediatorSubscriberBase
         _shockProvider = shockProvider;
         _clientDatListener = listener;
         _guideProvider = guideProvider;
+        _kinksters = kinksters;
 
         Flags = WFlags.NoScrollbar;
         this.PinningClickthroughFalse();
@@ -234,6 +239,15 @@ public class SettingsUi : WindowMediatorSubscriberBase
 
     private void AssignGlobalPermChangeTask(GlobalPerms perms, string globalKey, object newValue)
         => UiService.SetUITask(async () => await PermHelper.ChangeOwnGlobal(_hub, perms, globalKey, newValue));
+
+    private void AssignShockPermBulkTask(GlobalPerms perms, GlobalPerms updated)
+        => UiService.SetUITask(async () =>
+        {
+            if (ClientData.IsNull) return;
+            var res = await _hub.UserBulkChangeGlobal(new(MainHub.OwnUserData, updated, ClientData.HardcoreClone() ?? new HardcoreState()));
+            if (res.ErrorCode is GagSpeakApiEc.Success)
+                _clientDatListener.ChangeAllGlobalPerms(updated);
+        });
 
     // Do this better at some point!
     private void DrawGagSettings(GlobalPerms globals)
@@ -434,90 +448,59 @@ public class SettingsUi : WindowMediatorSubscriberBase
     private void DrawPiShockSettings(GlobalPerms globals)
     {
         var apiKey = _mainConfig.Current.PiShockApiKey;
-        var username = _mainConfig.Current.PiShockUsername;
-        var shareCode = globals.GlobalShockShareCode;
-        var allowShocks = globals.AllowShocks;
-        var allowVibrate = globals.AllowVibrations;
-        var allowBeep = globals.AllowBeeps;
-        var maxShockIntensity = globals.MaxIntensity;
-        var maxShockTime = globals.GetTimespanFromDuration();
 
-        using var node = ImRaii.TreeNode("Pi-Shock Global Settings");
-        if (node)
+        using var node = ImRaii.TreeNode("Pi-Shock Settings");
+        if (!node) return;
+
+        var inputWidth = 250 * ImGuiHelpers.GlobalScale;
+        var saveWidth = CkGui.IconTextButtonSize(FAI.PlugCircleCheck, "Save & Connect");
+
+        ImGui.SetNextItemWidth(inputWidth - saveWidth - ImGui.GetStyle().ItemInnerSpacing.X);
+        ImGui.InputText("##PiShock API Key", ref apiKey, 100);
+        CkGui.AttachTooltip(GSLoc.Settings.MainOptions.PiShockKeyTT);
+
+        ImUtf8.SameLineInner();
+        ImGui.TextUnformatted("API Key");
+
+        ImUtf8.SameLineInner();
+        if (CkGui.IconTextButton(FAI.PlugCircleCheck, "Save & Connect", disabled: UiService.DisableUI || string.IsNullOrEmpty(apiKey)))
         {
-            ImGui.SetNextItemWidth(250 * ImGuiHelpers.GlobalScale);
-            if (ImGui.InputText("PiShock API Key", ref apiKey, 100, ImGuiInputTextFlags.EnterReturnsTrue))
-            {
-                _mainConfig.Current.PiShockApiKey = apiKey;
-                _mainConfig.Save();
-            }
-            CkGui.HelpText(GSLoc.Settings.MainOptions.PiShockKeyTT);
-            CkGui.ColorText("API keys must be generated after Oct 15, 2024. If connection fails, re-login at login.pishock.com to validate your key.", ImGuiColors.DalamudYellow);
+            _mainConfig.Current.PiShockApiKey = apiKey;
+            _mainConfig.Save();
+            UiService.SetUITask(async () => await _shockProvider.ConnectAsync());
+        }
+        CkGui.AttachTooltip("Save your API key and fetch your connected PiShock devices.");
 
-            ImGui.SetNextItemWidth(250 * ImGuiHelpers.GlobalScale);
-            if (ImGui.InputText("PiShock Username", ref username, 100, ImGuiInputTextFlags.EnterReturnsTrue))
-            {
-                _mainConfig.Current.PiShockUsername = username;
-                _mainConfig.Save();
-            }
-            CkGui.HelpText(GSLoc.Settings.MainOptions.PiShockUsernameTT);
+        ImGui.Spacing();
 
-            var maxDuration = _mainConfig.Current.PiShockMaxDuration;
-            ImGui.SetNextItemWidth(250 * ImGuiHelpers.GlobalScale);
-            if (ImGui.SliderInt("Max Duration (s)##pishock", ref maxDuration, 1, 15))
-            {
-                _mainConfig.Current.PiShockMaxDuration = maxDuration;
-                _mainConfig.Save();
-            }
-            CkGui.HelpText("Maximum shock duration in seconds sent to Kinksters as your allowed limit. Click Refresh after changing.");
+        switch (_shockProvider.LastConnectState)
+        {
+            case PiShockProvider.ConnectState.NotAttempted:
+                if (!_shockProvider.IsConfigured)
+                    CkGui.ColorText("Enter your API Key, then click Save & Connect.", ImGuiColors.DalamudGrey);
+                else
+                    CkGui.ColorText("Click Save & Connect to detect your PiShock devices.", ImGuiColors.DalamudYellow);
+                break;
 
-            ImGui.SetNextItemWidth(250 * ImGuiHelpers.GlobalScale - CkGui.IconTextButtonSize(FAI.Sync, "Refresh") - ImGui.GetStyle().ItemInnerSpacing.X);
-            if (ImGui.InputText("##Global PiShock Share Code", ref shareCode, 100, ImGuiInputTextFlags.EnterReturnsTrue))
-                AssignGlobalPermChangeTask(globals, nameof(GlobalPerms.GlobalShockShareCode), shareCode);
+            case PiShockProvider.ConnectState.AuthFailed:
+                CkGui.ColorText("Authentication failed - check your API Key.", ImGuiColors.DalamudRed);
+                break;
 
-            ImUtf8.SameLineInner();
-            if (CkGui.IconTextButton(FAI.Sync, "Refresh", disabled: UiService.DisableUI))
-            {
-                UiService.SetUITask(async () =>
-                {
-                    if (ClientData.IsNull)
-                        return;
+            case PiShockProvider.ConnectState.NetworkError:
+                CkGui.ColorText("Connection error - check your internet or PiShock status.", ImGuiColors.DalamudRed);
+                break;
 
-                    var shareCodePerms = await _shockProvider.GetPermissionsFromCode(globals.GlobalShockShareCode);
-                    var newPerms = ClientData.GlobalsWithNewShockPermissions(shareCodePerms);
-                    var res = await _hub.UserBulkChangeGlobal(new(MainHub.OwnUserData, newPerms, ClientData.HardcoreClone() ?? new HardcoreState()));
-                    // be sure to invoke the changes manually when performed by self.
-                    if (res.ErrorCode is GagSpeakApiEc.Success)
-                        _clientDatListener.ChangeAllGlobalPerms(newPerms);
-                });
-            }
-            CkGui.AttachTooltip(GSLoc.Settings.MainOptions.PiShockShareCodeRefreshTT);
+            case PiShockProvider.ConnectState.Success when _shockProvider.ShockerCount == 0:
+                CkGui.ColorText("Connected - no devices found. Check your PiShock account.", ImGuiColors.DalamudYellow);
+                break;
 
-            ImUtf8.SameLineInner();
-            ImGui.TextUnformatted(GSLoc.Settings.MainOptions.PiShockShareCode);
-            CkGui.HelpText(GSLoc.Settings.MainOptions.PiShockShareCodeTT);
-
-            CkGui.ColorText(GSLoc.Settings.MainOptions.PiShockPermsLabel, ImGuiColors.ParsedGold);
-            using (ImRaii.Group())
-            {
-                CkGui.ColorTextBool(GSLoc.Settings.MainOptions.PiShockAllowShocks, allowShocks);
-                ImGui.SameLine();
-                CkGui.ColorTextBool(GSLoc.Settings.MainOptions.PiShockAllowVibes, allowVibrate);
-                ImGui.SameLine();
-                CkGui.ColorTextBool(GSLoc.Settings.MainOptions.PiShockAllowBeeps, allowBeep);
-
-                CkGui.FrameSeparatorV(2);
-
-                ImUtf8.TextFrameAligned(GSLoc.Settings.MainOptions.PiShockMaxShockIntensity);
-                CkGui.ColorTextFrameAlignedInline(maxShockIntensity.ToString() + "%", ImGuiColors.ParsedGold);
-
-                CkGui.FrameSeparatorV(2);
-
-                ImUtf8.TextFrameAligned(GSLoc.Settings.MainOptions.PiShockMaxShockDuration);
-                var maxGlobalShockDuration = globals.GetTimespanFromDuration();
-                CkGui.ColorTextFrameAlignedInline($"{maxGlobalShockDuration.Seconds}.{maxGlobalShockDuration.Milliseconds}s", ImGuiColors.ParsedGold);
-            }
-
+            case PiShockProvider.ConnectState.Success:
+                CkGui.ColorText($"{_shockProvider.ShockerCount} Available Shocker(s):", ImGuiColors.DalamudGrey);
+                foreach (var (_, name) in _shockProvider.CachedShockers)
+                    CkGui.ColorText($"  • {name}", ImGuiColors.HealerGreen);
+                ImGui.Spacing();
+                CkGui.ColorText("Configure a share code in each pair's permissions.", ImGuiColors.DalamudGrey);
+                break;
         }
     }
 

--- a/ProjectGagSpeak/WebAPI/PiShock/PiShockProvider.cs
+++ b/ProjectGagSpeak/WebAPI/PiShock/PiShockProvider.cs
@@ -1,11 +1,10 @@
+using CkCommons;
 using System.Net;
-using System.Net.WebSockets;
 using System.Text.Json;
 using GagSpeak.Kinksters;
 using GagSpeak.PlayerClient;
 using GagSpeak.Services.Mediator;
 using GagspeakAPI.Data.Struct;
-using GagspeakAPI.Hub;
 using GagspeakAPI.Network;
 using SysJsonSerializer = System.Text.Json.JsonSerializer;
 
@@ -13,299 +12,205 @@ namespace GagSpeak.WebAPI;
 
 public sealed class PiShockProvider : DisposableMediatorSubscriberBase
 {
-    private const string WsBrokerUri = "wss://broker.pishock.com/v2";
-    private const string PsBaseUri = "https://ps.pishock.com";
-    private const string AuthBaseUri = "https://auth.pishock.com";
+    private const string ApiBaseUri = "https://api.pishock.com";
 
     private readonly HttpClient _httpClient;
     private readonly MainConfig _mainConfig;
     private readonly KinksterManager _kinksters;
-    private readonly ClientData _clientData;
 
-    private ClientWebSocket? _ws;
-    private readonly SemaphoreSlim _wsSend = new(1, 1);
-    private CancellationTokenSource _wsCts = new();
-    private readonly Dictionary<string, (int ClientId, int ShockerId)> _resolvedShockers = new();
-    private int _userId = 0;
+    public enum ConnectState { NotAttempted, Success, AuthFailed, NetworkError }
+
+    private List<(int Id, string Name)> _cachedShockers = [];
+    private List<JsonElement> _cachedShockerData = [];
+    private ConnectState _connectState = ConnectState.NotAttempted;
+
+    public IReadOnlyList<(int Id, string Name)> CachedShockers => _cachedShockers;
+    public ConnectState LastConnectState => _connectState;
+    public bool IsConfigured => !string.IsNullOrEmpty(_mainConfig.Current.PiShockApiKey);
+    public int ShockerCount => _cachedShockers.Count;
 
     public PiShockProvider(ILogger<PiShockProvider> logger, GagspeakMediator mediator, MainConfig mainConfig,
-        KinksterManager kinksters, ClientData clientData)
+        KinksterManager kinksters)
         : base(logger, mediator)
     {
         _mainConfig = mainConfig;
         _kinksters = kinksters;
-        _clientData = clientData;
         _httpClient = new HttpClient();
+
+        Svc.ClientState.Login += OnLogin;
+        if (PlayerData.IsLoggedIn && IsConfigured)
+            _ = ConnectAsync();
     }
 
     protected override void Dispose(bool disposing)
     {
-        _wsCts.Cancel();
-        _ws?.Abort();
-        _ws?.Dispose();
-        _wsSend.Dispose();
-        _wsCts.Dispose();
         base.Dispose(disposing);
+        Svc.ClientState.Login -= OnLogin;
         _httpClient.Dispose();
     }
 
-    private async Task FetchUserIdAsync()
+    private void OnLogin()
     {
-        if (_userId != 0)
-            return;
+        if (IsConfigured)
+            _ = ConnectAsync();
+    }
 
-        var apikey = Uri.EscapeDataString(_mainConfig.Current.PiShockApiKey);
-        var username = Uri.EscapeDataString(_mainConfig.Current.PiShockUsername);
+    public async Task ConnectAsync()
+    {
+        _cachedShockers = [];
+        _cachedShockerData = [];
         try
         {
-            var resp = await _httpClient.GetAsync($"{AuthBaseUri}/Auth/GetUserIfAPIKeyValid?apikey={apikey}&username={username}").ConfigureAwait(false);
-            if (!resp.IsSuccessStatusCode) return;
+            var resp = await _httpClient.SendAsync(AuthedRequest(HttpMethod.Get, $"{ApiBaseUri}/Share/GetShared")).ConfigureAwait(false);
             var body = await resp.Content.ReadAsStringAsync().ConfigureAwait(false);
-            if (string.IsNullOrWhiteSpace(body)) return;
+            Logger.LogDebug("PiShock Connect: status={s} body={b}", (int)resp.StatusCode, body);
 
+            if (resp.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden)
+            {
+                _connectState = ConnectState.AuthFailed;
+                Logger.LogWarning("PiShock authentication failed (HTTP {code}).", (int)resp.StatusCode);
+                return;
+            }
+
+            if (!resp.IsSuccessStatusCode || string.IsNullOrWhiteSpace(body))
+            {
+                _connectState = ConnectState.NetworkError;
+                Logger.LogWarning("PiShock connection error (HTTP {code}).", (int)resp.StatusCode);
+                return;
+            }
+
+            _connectState = ConnectState.Success;
+            (_cachedShockers, _cachedShockerData) = ParseShockers(body);
+            Logger.LogInformation("PiShock connected: {count} device(s) found.", _cachedShockers.Count);
+        }
+        catch (Exception ex)
+        {
+            _connectState = ConnectState.NetworkError;
+            Logger.LogError(ex, "PiShock ConnectAsync network error.");
+        }
+    }
+
+    private static (List<(int Id, string Name)> Shockers, List<JsonElement> Data) ParseShockers(string body)
+    {
+        try
+        {
             using var doc = JsonDocument.Parse(body);
             var root = doc.RootElement;
-            var obj = root.ValueKind == JsonValueKind.Array ? root[0] : root;
-            if (obj.TryGetProperty("UserId", out var idProp))
-            {
-                _userId = idProp.GetInt32();
-                Logger.LogDebug("PiShock UserId resolved: {id}", _userId);
-            }
-        }
-        catch (Exception ex)
-        {
-            Logger.LogError(ex, "PiShock UserId fetch error");
-        }
-    }
+            JsonElement arr;
+            if (root.ValueKind == JsonValueKind.Array)
+                arr = root;
+            else if (root.TryGetProperty("value", out var nested) && nested.ValueKind == JsonValueKind.Array)
+                arr = nested;
+            else
+                return ([], []);
 
-    private async Task<bool> EnsureWsConnectedAsync()
-    {
-        if (_ws?.State == WebSocketState.Open)
-            return true;
-
-        try
-        {
-            _ws?.Dispose();
-            if (_wsCts.IsCancellationRequested)
-            {
-                _wsCts.Dispose();
-                _wsCts = new CancellationTokenSource();
-            }
-            _ws = new ClientWebSocket();
-            var username = Uri.EscapeDataString(_mainConfig.Current.PiShockUsername);
-            var apikey = Uri.EscapeDataString(_mainConfig.Current.PiShockApiKey);
-            var token = _wsCts.Token;
-            await _ws.ConnectAsync(new Uri($"{WsBrokerUri}?Username={username}&ApiKey={apikey}"), token).ConfigureAwait(false);
-
-            var ping = Encoding.UTF8.GetBytes("{\"Operation\":\"PING\"}");
-            await _ws.SendAsync(ping, WebSocketMessageType.Text, true, token).ConfigureAwait(false);
-
-            using var pingCts = CancellationTokenSource.CreateLinkedTokenSource(token);
-            pingCts.CancelAfter(4000);
-            var buf = new byte[4096];
-            var result = await _ws.ReceiveAsync(new ArraySegment<byte>(buf), pingCts.Token).ConfigureAwait(false);
-            var pongMsg = Encoding.UTF8.GetString(buf, 0, result.Count);
-            Logger.LogDebug("PiShock WS ping response: {msg}", pongMsg);
-
-            if (!pongMsg.Contains("PONG"))
-            {
-                try
+            var data = arr.EnumerateArray().Select(e => e.Clone()).ToList();
+            var shockers = data
+                .Where(s => (s.TryGetProperty("Id", out _) || s.TryGetProperty("id", out _)) &&
+                            (s.TryGetProperty("Name", out _) || s.TryGetProperty("name", out _)))
+                .Select(s =>
                 {
-                    using var doc = JsonDocument.Parse(pongMsg);
-                    if (doc.RootElement.TryGetProperty("IsError", out var isErr) && isErr.GetBoolean())
-                    {
-                        var errMsg = doc.RootElement.TryGetProperty("Message", out var m) ? m.GetString() : "unknown";
-                        Logger.LogError("PiShock WS auth failed: {msg}", errMsg);
-                        if (pongMsg.Contains("Redis") || pongMsg.Contains("API_KEY"))
-                            Logger.LogError("Fix: log out and back in at login.pishock.com to validate your API key");
-                    }
-                }
-                catch (System.Text.Json.JsonException) { }
-                _ws.Abort();
-                return false;
-            }
-
-            Logger.LogDebug("PiShock WebSocket connected and authenticated");
-            return true;
+                    var id = s.TryGetProperty("Id", out var ip) ? ip.GetInt32() : s.GetProperty("id").GetInt32();
+                    var name = s.TryGetProperty("Name", out var np) ? np.GetString() : s.GetProperty("name").GetString();
+                    return (id, name ?? "Unknown");
+                })
+                .DistinctBy(s => s.id)
+                .ToList();
+            return (shockers, data);
         }
-        catch (Exception ex)
-        {
-            Logger.LogError(ex, "PiShock WebSocket connection failed");
-            return false;
-        }
+        catch { return ([], []); }
     }
 
-    private async Task<string?> WsSendReceiveAsync(string json, int timeoutMs = 5000)
+    public int GetPairShockerId(string uid)
     {
-        var token = _wsCts.Token;
-        await _wsSend.WaitAsync(token).ConfigureAwait(false);
-        try
-        {
-            if (_ws == null || _ws.State != WebSocketState.Open)
-                return null;
-
-            await _ws.SendAsync(Encoding.UTF8.GetBytes(json), WebSocketMessageType.Text, true, token).ConfigureAwait(false);
-
-            using var cts = CancellationTokenSource.CreateLinkedTokenSource(token);
-            cts.CancelAfter(timeoutMs);
-            var buffer = new byte[8192];
-            var result = await _ws.ReceiveAsync(new ArraySegment<byte>(buffer), cts.Token).ConfigureAwait(false);
-            return result.MessageType == WebSocketMessageType.Text
-                ? Encoding.UTF8.GetString(buffer, 0, result.Count)
-                : null;
-        }
-        catch (OperationCanceledException)
-        {
-            Logger.LogWarning("PiShock WS timed out for: {json}", json);
-            return null;
-        }
-        catch (Exception ex)
-        {
-            Logger.LogError(ex, "PiShock WS send/receive error");
-            return null;
-        }
-        finally
-        {
-            _wsSend.Release();
-        }
+        if (_mainConfig.Current.PairShockerIds.TryGetValue(uid, out var id) && id != 0)
+            return id;
+        return _mainConfig.Current.GlobalShockerId;
     }
 
-    private async Task<List<int>> FetchShareIdsAsync(string apikey)
+    public void SetPairShockerId(string uid, int id)
     {
-        await FetchUserIdAsync().ConfigureAwait(false);
-
-        var urls = new List<string>();
-        if (_userId != 0)
-            urls.Add($"{PsBaseUri}/PiShock/GetShareCodesByOwner?UserId={_userId}&Token={apikey}&api=true");
-        urls.Add($"{PsBaseUri}/PiShock/GetShareCodesByOwner?Token={apikey}&api=true");
-
-        foreach (var url in urls)
-        {
-            try
-            {
-                var resp = await _httpClient.GetAsync(url).ConfigureAwait(false);
-                var body = await resp.Content.ReadAsStringAsync().ConfigureAwait(false);
-                Logger.LogDebug("PiShock GetShareCodesByOwner: status={s} body={b}", (int)resp.StatusCode, body);
-
-                if (!resp.IsSuccessStatusCode || string.IsNullOrWhiteSpace(body) || body == "{}") continue;
-
-                var ids = new List<int>();
-                using var doc = JsonDocument.Parse(body);
-                foreach (var entry in doc.RootElement.EnumerateObject())
-                    foreach (var idElem in entry.Value.EnumerateArray())
-                        ids.Add(idElem.GetInt32());
-
-                if (ids.Count > 0) return ids;
-            }
-            catch (Exception ex)
-            {
-                Logger.LogError(ex, "PiShock GetShareCodesByOwner error");
-            }
-        }
-        return [];
+        _mainConfig.Current.PairShockerIds[uid] = id;
+        _mainConfig.Save();
     }
 
-    private async Task<List<JsonElement>> FetchShockersByIdsAsync(string apikey, List<int> shareIds)
+    private HttpRequestMessage AuthedRequest(HttpMethod method, string url)
     {
-        var qs = string.Join("", shareIds.Select(id => $"&shareIds={id}"));
-
-        var urls = new List<string>();
-        if (_userId != 0)
-            urls.Add($"{PsBaseUri}/PiShock/GetShockersByShareIds?UserId={_userId}&Token={apikey}&api=true{qs}");
-        urls.Add($"{PsBaseUri}/PiShock/GetShockersByShareIds?Token={apikey}&api=true{qs}");
-
-        foreach (var url in urls)
-        {
-            try
-            {
-                var resp = await _httpClient.GetAsync(url).ConfigureAwait(false);
-                var body = await resp.Content.ReadAsStringAsync().ConfigureAwait(false);
-                Logger.LogDebug("PiShock GetShockersByShareIds: status={s} body={b}", (int)resp.StatusCode, body);
-
-                if (!resp.IsSuccessStatusCode || string.IsNullOrWhiteSpace(body)) continue;
-
-                var shockers = new List<JsonElement>();
-                using var doc = JsonDocument.Parse(body);
-                foreach (var entry in doc.RootElement.EnumerateObject())
-                    foreach (var shocker in entry.Value.EnumerateArray())
-                        shockers.Add(shocker.Clone());
-
-                if (shockers.Count > 0) return shockers;
-            }
-            catch (Exception ex)
-            {
-                Logger.LogError(ex, "PiShock GetShockersByShareIds error");
-            }
-        }
-        return [];
+        var req = new HttpRequestMessage(method, url);
+        req.Headers.Add("X-PiShock-Api-Key", _mainConfig.Current.PiShockApiKey);
+        return req;
     }
 
-    private async Task TryResolveShockerAsync(string shareCode)
-    {
-        if (_resolvedShockers.ContainsKey(shareCode))
-            return;
-
-        var apikey = Uri.EscapeDataString(_mainConfig.Current.PiShockApiKey);
-        var shareIds = await FetchShareIdsAsync(apikey).ConfigureAwait(false);
-        if (shareIds.Count == 0) return;
-
-        var shockers = await FetchShockersByIdsAsync(apikey, shareIds).ConfigureAwait(false);
-        foreach (var shocker in shockers)
-        {
-            if (!shocker.TryGetProperty("shareCode", out var scProp)) continue;
-            if (scProp.GetString()?.Equals(shareCode, StringComparison.OrdinalIgnoreCase) != true) continue;
-
-            var clientId = shocker.GetProperty("clientId").GetInt32();
-            var shockerId = shocker.GetProperty("shockerId").GetInt32();
-            _resolvedShockers[shareCode] = (clientId, shockerId);
-            Logger.LogDebug("PiShock shocker resolved: clientId={c} shockerId={s}", clientId, shockerId);
-            return;
-        }
-    }
-
-    public async Task<PiShockPermissions> GetPermissionsFromCode(string shareCode)
+    public Task<PiShockPermissions> GetPermissionsFromCode(string shareCode)
     {
         if (shareCode.IsNullOrEmpty())
         {
             Logger.LogWarning("Attempted to get PiShock permissions with empty share code.");
-            return new();
+            return Task.FromResult(new PiShockPermissions());
+        }
+
+        if (_connectState != ConnectState.Success || _cachedShockerData.Count == 0)
+        {
+            Logger.LogWarning("PiShock not connected or no devices cached. Connect via Settings first.");
+            return Task.FromResult(new PiShockPermissions());
         }
 
         try
         {
-            var apikey = Uri.EscapeDataString(_mainConfig.Current.PiShockApiKey);
-            var shareIds = await FetchShareIdsAsync(apikey).ConfigureAwait(false);
-
-            if (shareIds.Count > 0)
+            foreach (var shocker in _cachedShockerData)
             {
-                var shockers = await FetchShockersByIdsAsync(apikey, shareIds).ConfigureAwait(false);
-                foreach (var shocker in shockers)
-                {
-                    if (!shocker.TryGetProperty("shareCode", out var scProp)) continue;
-                    if (scProp.GetString()?.Equals(shareCode, StringComparison.OrdinalIgnoreCase) != true) continue;
+                var code = shocker.TryGetProperty("Code", out var cp)       ? cp.GetString()
+                         : shocker.TryGetProperty("code", out cp)           ? cp.GetString()
+                         : shocker.TryGetProperty("ShareCode", out var scp) ? scp.GetString()
+                         : shocker.TryGetProperty("shareCode", out scp)     ? scp.GetString()
+                         : null;
 
-                    var clientId = shocker.GetProperty("clientId").GetInt32();
-                    var shockerId = shocker.GetProperty("shockerId").GetInt32();
-                    var maxIntensity = shocker.GetProperty("maxIntensity").GetInt32();
-                    var canShock = shocker.GetProperty("canShock").GetBoolean();
-                    var canVibrate = shocker.GetProperty("canVibrate").GetBoolean();
-                    var canBeep = shocker.GetProperty("canBeep").GetBoolean();
+                if (code == null || !code.Equals(shareCode, StringComparison.OrdinalIgnoreCase))
+                    continue;
 
-                    _resolvedShockers[shareCode] = (clientId, shockerId);
-                    var maxDur = _mainConfig.Current.PiShockMaxDuration;
-                    Logger.LogTrace("PiShock permissions: shock={s} vibe={v} beep={b} maxIntensity={i} maxDuration={d}", canShock, canVibrate, canBeep, maxIntensity, maxDur);
-                    return new PiShockPermissions(canShock, canVibrate, canBeep, maxIntensity, maxDur);
-                }
-                Logger.LogWarning("PiShock share code {shareCode} not found among account shockers.", shareCode);
+                return Task.FromResult(ExtractPermissions(shocker));
             }
+
+            var targetId = _mainConfig.Current.GlobalShockerId;
+            if (targetId != 0)
+            {
+                foreach (var shocker in _cachedShockerData)
+                {
+                    if ((shocker.TryGetProperty("Id", out var idp) || shocker.TryGetProperty("id", out idp)) && idp.GetInt32() == targetId)
+                    {
+                        Logger.LogDebug("Share code not found by name, falling back to GlobalShockerId {id}", targetId);
+                        return Task.FromResult(ExtractPermissions(shocker));
+                    }
+                }
+            }
+
+            if (_cachedShockerData.Count > 0)
+            {
+                Logger.LogDebug("Share code not found, using first available shocker permissions");
+                return Task.FromResult(ExtractPermissions(_cachedShockerData[0]));
+            }
+
+            Logger.LogWarning("Share code {code} not found and no shockers available.", shareCode);
         }
         catch (Exception ex)
         {
-            Logger.LogError(ex, "PiShock permission discovery error");
+            Logger.LogError(ex, "PiShock GetPermissionsFromCode error");
         }
+        return Task.FromResult(new PiShockPermissions());
+    }
 
-        Logger.LogWarning("PiShock could not resolve permissions for {shareCode}.", shareCode);
-        return new();
+    private PiShockPermissions ExtractPermissions(JsonElement shocker)
+    {
+        var canShock   = (shocker.TryGetProperty("AllowShock",   out var s) || shocker.TryGetProperty("CanShock",   out s) ||
+                          shocker.TryGetProperty("allowShock",   out s)    || shocker.TryGetProperty("canShock",   out s)) && s.GetBoolean();
+        var canVibrate = (shocker.TryGetProperty("AllowVibrate", out var v) || shocker.TryGetProperty("CanVibrate", out v) ||
+                          shocker.TryGetProperty("allowVibrate", out v)    || shocker.TryGetProperty("canVibrate", out v)) && v.GetBoolean();
+        var canBeep    = (shocker.TryGetProperty("AllowBeep",    out var b) || shocker.TryGetProperty("CanBeep",    out b) ||
+                          shocker.TryGetProperty("allowBeep",    out b)    || shocker.TryGetProperty("canBeep",    out b)) && b.GetBoolean();
+        var maxIntensity = (shocker.TryGetProperty("MaxIntensity", out var mi) || shocker.TryGetProperty("maxIntensity", out mi)) ? mi.GetInt32() : 100;
+        var maxDuration  = (shocker.TryGetProperty("MaxDuration",  out var md) || shocker.TryGetProperty("maxDuration",  out md)) ? md.GetInt32() : 15;
+        Logger.LogDebug("PiShock permissions: shock={s} vibe={v} beep={b} maxI={i} maxD={d}", canShock, canVibrate, canBeep, maxIntensity, maxDuration);
+        return new PiShockPermissions(canShock, canVibrate, canBeep, maxIntensity, maxDuration);
     }
 
     public void PerformShockCollarAct(ShockCollarAction dto)
@@ -317,103 +222,71 @@ public sealed class PiShockProvider : DisposableMediatorSubscriberBase
         var eventLogMessage = $"Pishock {interactionType}, intensity: {dto.Intensity}, duration: {dto.Duration}";
         Logger.LogDebug($"Received Instruction for {eventLogMessage}", LoggerType.Callbacks);
 
-        // PiShock treats d<=15 as seconds and d>15 as milliseconds; enforce 100ms minimum to avoid the ambiguous range.
-        if (dto.Duration < 100)
-            dto = dto with { Duration = 100 };
-
-        if (!enactor.OwnPerms.PiShockShareCode.IsNullOrEmpty())
+        if (dto.Duration < 1000)
         {
-            if (dto.Duration / 1000f > enactor.OwnPerms.MaxDuration || (dto.OpCode != 2 && dto.Intensity > enactor.OwnPerms.MaxIntensity))
-            {
-                Logger.LogWarning("Received instruction that exceeds the max duration or intensity for this user. Ignoring.");
-                return;
-            }
+            Logger.LogDebug("Shock duration {orig}ms below minimum, raising to 1000ms.", dto.Duration);
+            dto = dto with { Duration = 1000 };
+        }
 
-            Logger.LogDebug("Executing Shock Instruction to UniquePair ShareCode", LoggerType.Callbacks);
-            Mediator.Publish(new EventMessage(new(enactor.GetNickAliasOrUid(), enactor.UserData.UID, InteractionType.PiShockUpdate, eventLogMessage)));
-            ExecuteOperation(enactor.OwnPerms.PiShockShareCode, dto.OpCode, dto.Intensity, dto.Duration);
-            if (dto.OpCode is 0)
-                GagspeakEventManager.AchievementEvent(UnlocksEvent.ShockReceived);
-        }
-        else if (ClientData.Globals is { } g && !g.GlobalShockShareCode.IsNullOrEmpty())
+        var shockerId = GetPairShockerId(dto.User.UID);
+        if (shockerId == 0)
         {
-            if (dto.Duration / 1000f > g.MaxDuration || (dto.OpCode != 2 && dto.Intensity > g.MaxIntensity))
-            {
-                Logger.LogWarning("Received instruction that exceeds the max duration or intensity for this user. Ignoring.");
-                return;
-            }
+            Logger.LogWarning("Received shock instruction but no shocker is configured for user {uid}.", dto.User.UID);
+            return;
+        }
 
-            Logger.LogDebug("Executing Shock Instruction to Global ShareCode", LoggerType.Callbacks);
-            Mediator.Publish(new EventMessage(new(enactor.GetNickAliasOrUid(), enactor.UserData.UID, InteractionType.PiShockUpdate, eventLogMessage)));
-            ExecuteOperation(g.GlobalShockShareCode, dto.OpCode, dto.Intensity, dto.Duration);
-            if (dto.OpCode is 0)
-                GagspeakEventManager.AchievementEvent(UnlocksEvent.ShockReceived);
-        }
-        else
+        var opAllowed = dto.OpCode switch
         {
-            Logger.LogWarning("Someone Attempted to execute an instruction to you, but you don't have any share codes enabled!");
+            0 => enactor.OwnPerms.AllowShocks,
+            1 => enactor.OwnPerms.AllowVibrations,
+            2 => enactor.OwnPerms.AllowBeeps,
+            _ => false
+        };
+        if (!opAllowed)
+        {
+            Logger.LogWarning("Received opcode {op} but that operation is not permitted for {uid}.", dto.OpCode, dto.User.UID);
+            return;
         }
+
+        if (dto.Duration / 1000f > enactor.OwnPerms.GetTimespanFromDuration().TotalSeconds || (dto.OpCode != 2 && dto.Intensity > enactor.OwnPerms.MaxIntensity))
+        {
+            Logger.LogWarning("Received instruction that exceeds the max duration or intensity for this user. Ignoring.");
+            return;
+        }
+
+        Logger.LogDebug("Executing Shock Instruction via pair permissions.", LoggerType.Callbacks);
+        Mediator.Publish(new EventMessage(new(enactor.GetNickAliasOrUid(), enactor.UserData.UID, InteractionType.PiShockUpdate, eventLogMessage)));
+        ExecuteOperation(shockerId, dto.OpCode, dto.Intensity, dto.Duration);
+        if (dto.OpCode is 0)
+            GagspeakEventManager.AchievementEvent(UnlocksEvent.ShockReceived);
     }
 
-    public async void ExecuteOperation(string shareCode, int opCode, int intensity, int duration)
+    public async void ExecuteOperation(int shockerId, int opCode, int intensity, int duration)
     {
-        if (!_resolvedShockers.ContainsKey(shareCode))
-            await TryResolveShockerAsync(shareCode).ConfigureAwait(false);
-
-        if (!await EnsureWsConnectedAsync().ConfigureAwait(false))
+        try
         {
-            Logger.LogError("PiShock WebSocket unavailable, cannot execute operation");
-            return;
-        }
-
-        var mode = opCode switch { 0 => "s", 1 => "v", 2 => "b", _ => "s" };
-        string target;
-        int shockerId;
-
-        if (!_resolvedShockers.TryGetValue(shareCode, out var shocker))
-        {
-            Logger.LogError("PiShock shocker unresolved for {shareCode}, cannot send operation", shareCode);
-            return;
-        }
-
-        target = $"c{shocker.ClientId}-sops-{shareCode}";
-        shockerId = shocker.ShockerId;
-
-        var payload = SysJsonSerializer.Serialize(new
-        {
-            Operation = "PUBLISH",
-            PublishCommands = new[]
-            {
-                new
+            var req = AuthedRequest(HttpMethod.Post, $"{ApiBaseUri}/Shockers/{shockerId}");
+            var durationMs   = Math.Clamp(duration, 300, 15000);
+            var intensityPct = Math.Clamp(intensity, 0, 100);
+            req.Content = new StringContent(
+                SysJsonSerializer.Serialize(new
                 {
-                    Target = target,
-                    Body = new
-                    {
-                        id = shockerId,
-                        m = mode,
-                        i = intensity,
-                        d = duration,
-                        r = true,
-                        l = new { u = _userId, ty = "sc", w = false, o = "GagSpeak" }
-                    }
-                }
-            }
-        });
-
-        Logger.LogTrace("PiShock WS PUBLISH: {payload}", payload);
-        var wsResponse = await WsSendReceiveAsync(payload).ConfigureAwait(false);
-        Logger.LogDebug("PiShock WS response: {response}", wsResponse ?? "(null)");
-
-        if (wsResponse != null)
+                    AgentName            = "GagSpeak",
+                    Operation            = opCode,
+                    Duration             = durationMs,
+                    Intensity            = intensityPct,
+                    IntensityAsPercentage = true,
+                }), Encoding.UTF8, "application/json");
+            var resp = await _httpClient.SendAsync(req).ConfigureAwait(false);
+            var body = await resp.Content.ReadAsStringAsync().ConfigureAwait(false);
+            if (resp.IsSuccessStatusCode)
+                Logger.LogDebug("PiShock operation sent successfully (HTTP {code})", (int)resp.StatusCode);
+            else
+                Logger.LogWarning("PiShock operation returned unexpected status: {status} body={b}", (int)resp.StatusCode, body);
+        }
+        catch (Exception ex)
         {
-            try
-            {
-                using var doc = JsonDocument.Parse(wsResponse);
-                if (doc.RootElement.TryGetProperty("IsError", out var isErrorProp) && isErrorProp.GetBoolean())
-                    Logger.LogError("PiShock WS error: {msg}",
-                        doc.RootElement.TryGetProperty("Message", out var msg) ? msg.GetString() : "unknown");
-            }
-            catch (System.Text.Json.JsonException) { }
+            Logger.LogError(ex, "PiShock operation error");
         }
     }
 }

--- a/ProjectGagSpeak/WebAPI/PiShock/PiShockProvider.cs
+++ b/ProjectGagSpeak/WebAPI/PiShock/PiShockProvider.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Net.WebSockets;
 using System.Text.Json;
 using GagSpeak.Kinksters;
 using GagSpeak.PlayerClient;
@@ -12,10 +13,20 @@ namespace GagSpeak.WebAPI;
 
 public sealed class PiShockProvider : DisposableMediatorSubscriberBase
 {
+    private const string WsBrokerUri = "wss://broker.pishock.com/v2";
+    private const string PsBaseUri = "https://ps.pishock.com";
+    private const string AuthBaseUri = "https://auth.pishock.com";
+
     private readonly HttpClient _httpClient;
     private readonly MainConfig _mainConfig;
     private readonly KinksterManager _kinksters;
     private readonly ClientData _clientData;
+
+    private ClientWebSocket? _ws;
+    private readonly SemaphoreSlim _wsSend = new(1, 1);
+    private CancellationTokenSource _wsCts = new();
+    private readonly Dictionary<string, (int ClientId, int ShockerId)> _resolvedShockers = new();
+    private int _userId = 0;
 
     public PiShockProvider(ILogger<PiShockProvider> logger, GagspeakMediator mediator, MainConfig mainConfig,
         KinksterManager kinksters, ClientData clientData)
@@ -29,52 +40,227 @@ public sealed class PiShockProvider : DisposableMediatorSubscriberBase
 
     protected override void Dispose(bool disposing)
     {
+        _wsCts.Cancel();
+        _ws?.Abort();
+        _ws?.Dispose();
+        _wsSend.Dispose();
+        _wsCts.Dispose();
         base.Dispose(disposing);
         _httpClient.Dispose();
     }
 
-    // grab basic information from shock collar.
-    private StringContent CreateGetInfoContent(string shareCode)
+    private async Task FetchUserIdAsync()
     {
-        StringContent content = new(SysJsonSerializer.Serialize(new
+        if (_userId != 0)
+            return;
+
+        var apikey = Uri.EscapeDataString(_mainConfig.Current.PiShockApiKey);
+        var username = Uri.EscapeDataString(_mainConfig.Current.PiShockUsername);
+        try
         {
-            UserName = _mainConfig.Current.PiShockUsername,
-            Code = shareCode,
-            Apikey = _mainConfig.Current.PiShockApiKey,
-        }), Encoding.UTF8, "application/json");
-        return content;
+            var resp = await _httpClient.GetAsync($"{AuthBaseUri}/Auth/GetUserIfAPIKeyValid?apikey={apikey}&username={username}").ConfigureAwait(false);
+            if (!resp.IsSuccessStatusCode) return;
+            var body = await resp.Content.ReadAsStringAsync().ConfigureAwait(false);
+            if (string.IsNullOrWhiteSpace(body)) return;
+
+            using var doc = JsonDocument.Parse(body);
+            var root = doc.RootElement;
+            var obj = root.ValueKind == JsonValueKind.Array ? root[0] : root;
+            if (obj.TryGetProperty("UserId", out var idProp))
+            {
+                _userId = idProp.GetInt32();
+                Logger.LogDebug("PiShock UserId resolved: {id}", _userId);
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "PiShock UserId fetch error");
+        }
     }
 
-    // For grabbing boolean permissions from a share code.
-    private StringContent CreateDummyExecuteContent(string shareCode, int opCode)
+    private async Task<bool> EnsureWsConnectedAsync()
     {
-        StringContent content = new(SysJsonSerializer.Serialize(new
+        if (_ws?.State == WebSocketState.Open)
+            return true;
+
+        try
         {
-            Username = _mainConfig.Current.PiShockUsername,
-            Name = "GagSpeakProvider",
-            Op = opCode,
-            Intensity = 0,
-            Duration = 0,
-            Code = shareCode,
-            Apikey = _mainConfig.Current.PiShockApiKey,
-        }), Encoding.UTF8, "application/json");
-        return content;
+            _ws?.Dispose();
+            if (_wsCts.IsCancellationRequested)
+            {
+                _wsCts.Dispose();
+                _wsCts = new CancellationTokenSource();
+            }
+            _ws = new ClientWebSocket();
+            var username = Uri.EscapeDataString(_mainConfig.Current.PiShockUsername);
+            var apikey = Uri.EscapeDataString(_mainConfig.Current.PiShockApiKey);
+            var token = _wsCts.Token;
+            await _ws.ConnectAsync(new Uri($"{WsBrokerUri}?Username={username}&ApiKey={apikey}"), token).ConfigureAwait(false);
+
+            var ping = Encoding.UTF8.GetBytes("{\"Operation\":\"PING\"}");
+            await _ws.SendAsync(ping, WebSocketMessageType.Text, true, token).ConfigureAwait(false);
+
+            using var pingCts = CancellationTokenSource.CreateLinkedTokenSource(token);
+            pingCts.CancelAfter(4000);
+            var buf = new byte[4096];
+            var result = await _ws.ReceiveAsync(new ArraySegment<byte>(buf), pingCts.Token).ConfigureAwait(false);
+            var pongMsg = Encoding.UTF8.GetString(buf, 0, result.Count);
+            Logger.LogDebug("PiShock WS ping response: {msg}", pongMsg);
+
+            if (!pongMsg.Contains("PONG"))
+            {
+                try
+                {
+                    using var doc = JsonDocument.Parse(pongMsg);
+                    if (doc.RootElement.TryGetProperty("IsError", out var isErr) && isErr.GetBoolean())
+                    {
+                        var errMsg = doc.RootElement.TryGetProperty("Message", out var m) ? m.GetString() : "unknown";
+                        Logger.LogError("PiShock WS auth failed: {msg}", errMsg);
+                        if (pongMsg.Contains("Redis") || pongMsg.Contains("API_KEY"))
+                            Logger.LogError("Fix: log out and back in at login.pishock.com to validate your API key");
+                    }
+                }
+                catch (System.Text.Json.JsonException) { }
+                _ws.Abort();
+                return false;
+            }
+
+            Logger.LogDebug("PiShock WebSocket connected and authenticated");
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "PiShock WebSocket connection failed");
+            return false;
+        }
     }
 
-    // Sends operation to shock collar
-    private StringContent CreateExecuteOperationContent(string shareCode, int opCode, int intensity, int duration)
+    private async Task<string?> WsSendReceiveAsync(string json, int timeoutMs = 5000)
     {
-        StringContent content = new(SysJsonSerializer.Serialize(new
+        var token = _wsCts.Token;
+        await _wsSend.WaitAsync(token).ConfigureAwait(false);
+        try
         {
-            Username = _mainConfig.Current.PiShockUsername,
-            Name = "GagSpeakProvider",
-            Op = opCode,
-            Intensity = intensity,
-            Duration = duration,
-            Code = shareCode,
-            Apikey = _mainConfig.Current.PiShockApiKey,
-        }), Encoding.UTF8, "application/json");
-        return content;
+            if (_ws == null || _ws.State != WebSocketState.Open)
+                return null;
+
+            await _ws.SendAsync(Encoding.UTF8.GetBytes(json), WebSocketMessageType.Text, true, token).ConfigureAwait(false);
+
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(token);
+            cts.CancelAfter(timeoutMs);
+            var buffer = new byte[8192];
+            var result = await _ws.ReceiveAsync(new ArraySegment<byte>(buffer), cts.Token).ConfigureAwait(false);
+            return result.MessageType == WebSocketMessageType.Text
+                ? Encoding.UTF8.GetString(buffer, 0, result.Count)
+                : null;
+        }
+        catch (OperationCanceledException)
+        {
+            Logger.LogWarning("PiShock WS timed out for: {json}", json);
+            return null;
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "PiShock WS send/receive error");
+            return null;
+        }
+        finally
+        {
+            _wsSend.Release();
+        }
+    }
+
+    private async Task<List<int>> FetchShareIdsAsync(string apikey)
+    {
+        await FetchUserIdAsync().ConfigureAwait(false);
+
+        var urls = new List<string>();
+        if (_userId != 0)
+            urls.Add($"{PsBaseUri}/PiShock/GetShareCodesByOwner?UserId={_userId}&Token={apikey}&api=true");
+        urls.Add($"{PsBaseUri}/PiShock/GetShareCodesByOwner?Token={apikey}&api=true");
+
+        foreach (var url in urls)
+        {
+            try
+            {
+                var resp = await _httpClient.GetAsync(url).ConfigureAwait(false);
+                var body = await resp.Content.ReadAsStringAsync().ConfigureAwait(false);
+                Logger.LogDebug("PiShock GetShareCodesByOwner: status={s} body={b}", (int)resp.StatusCode, body);
+
+                if (!resp.IsSuccessStatusCode || string.IsNullOrWhiteSpace(body) || body == "{}") continue;
+
+                var ids = new List<int>();
+                using var doc = JsonDocument.Parse(body);
+                foreach (var entry in doc.RootElement.EnumerateObject())
+                    foreach (var idElem in entry.Value.EnumerateArray())
+                        ids.Add(idElem.GetInt32());
+
+                if (ids.Count > 0) return ids;
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "PiShock GetShareCodesByOwner error");
+            }
+        }
+        return [];
+    }
+
+    private async Task<List<JsonElement>> FetchShockersByIdsAsync(string apikey, List<int> shareIds)
+    {
+        var qs = string.Join("", shareIds.Select(id => $"&shareIds={id}"));
+
+        var urls = new List<string>();
+        if (_userId != 0)
+            urls.Add($"{PsBaseUri}/PiShock/GetShockersByShareIds?UserId={_userId}&Token={apikey}&api=true{qs}");
+        urls.Add($"{PsBaseUri}/PiShock/GetShockersByShareIds?Token={apikey}&api=true{qs}");
+
+        foreach (var url in urls)
+        {
+            try
+            {
+                var resp = await _httpClient.GetAsync(url).ConfigureAwait(false);
+                var body = await resp.Content.ReadAsStringAsync().ConfigureAwait(false);
+                Logger.LogDebug("PiShock GetShockersByShareIds: status={s} body={b}", (int)resp.StatusCode, body);
+
+                if (!resp.IsSuccessStatusCode || string.IsNullOrWhiteSpace(body)) continue;
+
+                var shockers = new List<JsonElement>();
+                using var doc = JsonDocument.Parse(body);
+                foreach (var entry in doc.RootElement.EnumerateObject())
+                    foreach (var shocker in entry.Value.EnumerateArray())
+                        shockers.Add(shocker.Clone());
+
+                if (shockers.Count > 0) return shockers;
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "PiShock GetShockersByShareIds error");
+            }
+        }
+        return [];
+    }
+
+    private async Task TryResolveShockerAsync(string shareCode)
+    {
+        if (_resolvedShockers.ContainsKey(shareCode))
+            return;
+
+        var apikey = Uri.EscapeDataString(_mainConfig.Current.PiShockApiKey);
+        var shareIds = await FetchShareIdsAsync(apikey).ConfigureAwait(false);
+        if (shareIds.Count == 0) return;
+
+        var shockers = await FetchShockersByIdsAsync(apikey, shareIds).ConfigureAwait(false);
+        foreach (var shocker in shockers)
+        {
+            if (!shocker.TryGetProperty("shareCode", out var scProp)) continue;
+            if (scProp.GetString()?.Equals(shareCode, StringComparison.OrdinalIgnoreCase) != true) continue;
+
+            var clientId = shocker.GetProperty("clientId").GetInt32();
+            var shockerId = shocker.GetProperty("shockerId").GetInt32();
+            _resolvedShockers[shareCode] = (clientId, shockerId);
+            Logger.LogDebug("PiShock shocker resolved: clientId={c} shockerId={s}", clientId, shockerId);
+            return;
+        }
     }
 
     public async Task<PiShockPermissions> GetPermissionsFromCode(string shareCode)
@@ -84,88 +270,46 @@ public sealed class PiShockProvider : DisposableMediatorSubscriberBase
             Logger.LogWarning("Attempted to get PiShock permissions with empty share code.");
             return new();
         }
-        try
-        {
-            var jsonContent = CreateGetInfoContent(shareCode);
-
-            Logger.LogTrace("PiShock Request Info URI Firing: {piShockUri}", GagspeakPiShock.GetInfoPath());
-            var response = await _httpClient.PostAsync(GagspeakPiShock.GetInfoPath(), jsonContent).ConfigureAwait(false);
-
-            if (response.StatusCode == HttpStatusCode.OK)
-            {
-                Logger.LogTrace("PiShock Request Info Response: {response}", response);
-                var content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-                Logger.LogTrace("PiShock Request Info Content: {content}", content);
-                var jsonDocument = JsonDocument.Parse(content);
-                var root = jsonDocument.RootElement;
-
-                var maxIntensity = root.GetProperty("maxIntensity").GetInt32();
-                var maxShockDuration = root.GetProperty("maxDuration").GetInt32();
-
-                Logger.LogTrace("Obtaining boolean values by passing dummy requests to share code");
-                var result = await ConstructPermissionObject(shareCode, maxIntensity, maxShockDuration);
-                Logger.LogTrace("PiShock Permissions obtained: {result}", result);
-                return result;
-            }
-            else if (response.StatusCode == HttpStatusCode.InternalServerError)
-            {
-                Logger.LogWarning("The Credentials for your API Key and Username do not match any profile in PiShock");
-                return new();
-            }
-            else
-            {
-                Logger.LogError("The ShareCode for this profile does not exist, or this is a simple error 404: {statusCode}", response.StatusCode);
-                return new();
-            }
-        }
-        catch (HttpRequestException ex)
-        {
-            Logger.LogError(ex, "Error getting PiShock permissions from share code");
-            return new PiShockPermissions();
-        }
-    }
-
-    private async Task<PiShockPermissions> ConstructPermissionObject(string shareCode, int intensityLimit, int durationLimit)
-    {
-        // Shock, Vibrate, Beep. In that order
-        int[] opCodes = { 0, 1, 2 };
-        var shocks = false;
-        var vibrations = false;
-        var beeps = false;
 
         try
         {
-            foreach (var opCode in opCodes)
+            var apikey = Uri.EscapeDataString(_mainConfig.Current.PiShockApiKey);
+            var shareIds = await FetchShareIdsAsync(apikey).ConfigureAwait(false);
+
+            if (shareIds.Count > 0)
             {
-                var jsonContent = CreateDummyExecuteContent(shareCode, opCode);
-                var response = await _httpClient.PostAsync(GagspeakPiShock.ExecuteOperationPath(), jsonContent).ConfigureAwait(false);
-
-                if (response.StatusCode != HttpStatusCode.OK) continue;
-
-                var content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-
-                switch (opCode)
+                var shockers = await FetchShockersByIdsAsync(apikey, shareIds).ConfigureAwait(false);
+                foreach (var shocker in shockers)
                 {
-                    case 0:
-                        shocks = content! == "Operation Attempted."; break;
-                    case 1:
-                        vibrations = content! == "Operation Attempted."; break;
-                    case 2:
-                        beeps = content! == "Operation Attempted."; break;
+                    if (!shocker.TryGetProperty("shareCode", out var scProp)) continue;
+                    if (scProp.GetString()?.Equals(shareCode, StringComparison.OrdinalIgnoreCase) != true) continue;
+
+                    var clientId = shocker.GetProperty("clientId").GetInt32();
+                    var shockerId = shocker.GetProperty("shockerId").GetInt32();
+                    var maxIntensity = shocker.GetProperty("maxIntensity").GetInt32();
+                    var canShock = shocker.GetProperty("canShock").GetBoolean();
+                    var canVibrate = shocker.GetProperty("canVibrate").GetBoolean();
+                    var canBeep = shocker.GetProperty("canBeep").GetBoolean();
+
+                    _resolvedShockers[shareCode] = (clientId, shockerId);
+                    var maxDur = _mainConfig.Current.PiShockMaxDuration;
+                    Logger.LogTrace("PiShock permissions: shock={s} vibe={v} beep={b} maxIntensity={i} maxDuration={d}", canShock, canVibrate, canBeep, maxIntensity, maxDur);
+                    return new PiShockPermissions(canShock, canVibrate, canBeep, maxIntensity, maxDur);
                 }
+                Logger.LogWarning("PiShock share code {shareCode} not found among account shockers.", shareCode);
             }
         }
-        catch (HttpRequestException ex)
+        catch (Exception ex)
         {
-            Logger.LogError(ex, "Error executing operation on PiShock");
+            Logger.LogError(ex, "PiShock permission discovery error");
         }
 
-        return new PiShockPermissions() { AllowShocks = shocks, AllowVibrations = vibrations, AllowBeeps = beeps, MaxIntensity = intensityLimit, MaxDuration = durationLimit };
+        Logger.LogWarning("PiShock could not resolve permissions for {shareCode}.", shareCode);
+        return new();
     }
 
     public void PerformShockCollarAct(ShockCollarAction dto)
     {
-        // figure out who sent the command, and see if we have a unique sharecode setup for them.
         if (!_kinksters.TryGetKinkster(dto.User, out var enactor))
             throw new InvalidOperationException($"Shock Collar Action received from non-kinkster user: {dto.User.AliasOrUID}");
 
@@ -173,16 +317,12 @@ public sealed class PiShockProvider : DisposableMediatorSubscriberBase
         var eventLogMessage = $"Pishock {interactionType}, intensity: {dto.Intensity}, duration: {dto.Duration}";
         Logger.LogDebug($"Received Instruction for {eventLogMessage}", LoggerType.Callbacks);
 
-        // Handle quirk in pishock API where it accepts durations in seconds up to 15, but anything above 15 is treated as milliseconds.
-        // Our slider only accepts 0.1 second increments, so we will enforce a minimum of 100 milliseconds to avoid the aforementioned issue.
+        // PiShock treats d<=15 as seconds and d>15 as milliseconds; enforce 100ms minimum to avoid the ambiguous range.
         if (dto.Duration < 100)
-        {
             dto = dto with { Duration = 100 };
-        }
 
         if (!enactor.OwnPerms.PiShockShareCode.IsNullOrEmpty())
         {
-            // MaxDuration is in seconds while the incoming duration is in ms, so we need to convert before comparing. Ignore intensity for beeps.
             if (dto.Duration / 1000f > enactor.OwnPerms.MaxDuration || (dto.OpCode != 2 && dto.Intensity > enactor.OwnPerms.MaxIntensity))
             {
                 Logger.LogWarning("Received instruction that exceeds the max duration or intensity for this user. Ignoring.");
@@ -197,7 +337,6 @@ public sealed class PiShockProvider : DisposableMediatorSubscriberBase
         }
         else if (ClientData.Globals is { } g && !g.GlobalShockShareCode.IsNullOrEmpty())
         {
-            // MaxDuration is in seconds while the incoming duration is in ms, so we need to convert before comparing. Ignore intensity for beeps.
             if (dto.Duration / 1000f > g.MaxDuration || (dto.OpCode != 2 && dto.Intensity > g.MaxIntensity))
             {
                 Logger.LogWarning("Received instruction that exceeds the max duration or intensity for this user. Ignoring.");
@@ -218,22 +357,63 @@ public sealed class PiShockProvider : DisposableMediatorSubscriberBase
 
     public async void ExecuteOperation(string shareCode, int opCode, int intensity, int duration)
     {
-        try
-        {
-            var jsonContent = CreateExecuteOperationContent(shareCode, opCode, intensity, duration);
-            var response = await _httpClient.PostAsync(GagspeakPiShock.ExecuteOperationPath(), jsonContent).ConfigureAwait(false);
+        if (!_resolvedShockers.ContainsKey(shareCode))
+            await TryResolveShockerAsync(shareCode).ConfigureAwait(false);
 
-            if (response.StatusCode != HttpStatusCode.OK)
-            {
-                Logger.LogError("Error executing operation on PiShock. Status returned: " + response.StatusCode);
-                return;
-            }
-            var contentStr = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-            Logger.LogDebug("PiShock Request Sent to Shock Collar Successfully! Content returned was:\n" + contentStr);
-        }
-        catch (HttpRequestException ex)
+        if (!await EnsureWsConnectedAsync().ConfigureAwait(false))
         {
-            Logger.LogError(ex, "Error executing operation on PiShock");
+            Logger.LogError("PiShock WebSocket unavailable, cannot execute operation");
+            return;
+        }
+
+        var mode = opCode switch { 0 => "s", 1 => "v", 2 => "b", _ => "s" };
+        string target;
+        int shockerId;
+
+        if (!_resolvedShockers.TryGetValue(shareCode, out var shocker))
+        {
+            Logger.LogError("PiShock shocker unresolved for {shareCode}, cannot send operation", shareCode);
+            return;
+        }
+
+        target = $"c{shocker.ClientId}-sops-{shareCode}";
+        shockerId = shocker.ShockerId;
+
+        var payload = SysJsonSerializer.Serialize(new
+        {
+            Operation = "PUBLISH",
+            PublishCommands = new[]
+            {
+                new
+                {
+                    Target = target,
+                    Body = new
+                    {
+                        id = shockerId,
+                        m = mode,
+                        i = intensity,
+                        d = duration,
+                        r = true,
+                        l = new { u = _userId, ty = "sc", w = false, o = "GagSpeak" }
+                    }
+                }
+            }
+        });
+
+        Logger.LogTrace("PiShock WS PUBLISH: {payload}", payload);
+        var wsResponse = await WsSendReceiveAsync(payload).ConfigureAwait(false);
+        Logger.LogDebug("PiShock WS response: {response}", wsResponse ?? "(null)");
+
+        if (wsResponse != null)
+        {
+            try
+            {
+                using var doc = JsonDocument.Parse(wsResponse);
+                if (doc.RootElement.TryGetProperty("IsError", out var isErrorProp) && isErrorProp.GetBoolean())
+                    Logger.LogError("PiShock WS error: {msg}",
+                        doc.RootElement.TryGetProperty("Message", out var msg) ? msg.GetString() : "unknown");
+            }
+            catch (System.Text.Json.JsonException) { }
         }
     }
 }


### PR DESCRIPTION
PiShock retired their old API, the legacy endpoints just 404 now, so the integration was fully broken. This rewrites it on the new api.pishock.com REST API

Auth is just the API key now (header based), so the username field is gone since it isn't needed anymore shockers are resolved with GET /Share/GetShared and operated with POST /Shockers/{id}

Settings side: removed the global share code (share codes are per-pair now), and added a device selector to pick which shocker the triggers use Limits (max intensity, duration, allowed modes) still come from the share, and PiShock clamps them server-side

I electrocuted myself 3 times by accident trying to set up triggers and it hurt >'< 