### PR TITLE
fix: active restraint sets selector when set is already active

### DIFF
--- a/ProjectGagSpeak/CustomCombos/EditorCombos/RestraintCombo.cs
+++ b/ProjectGagSpeak/CustomCombos/EditorCombos/RestraintCombo.cs
@@ -56,6 +56,13 @@ public sealed class RestraintCombo : CkFilterComboCache<RestraintSet>, IMediator
         var preview = Items.FirstOrDefault(i => i.Identifier == current)?.Label ?? "Select Restraint...";
         return Draw(label, preview, string.Empty, width, ImGui.GetTextLineHeightWithSpacing(), flags, customSearchBg);
     }
+    
+    public bool DrawPopup(string label, Guid current, float width, Vector2 drawPos, uint? searchBg = null)
+    {
+        InnerWidth = width * 1.25f;
+        _currentRestraint = current;
+        return DrawPopup(label, drawPos, ImGui.GetTextLineHeightWithSpacing(), searchBg);
+    }
 
     protected override bool DrawSelectable(int globalIdx, bool selected)
     {

--- a/ProjectGagSpeak/UI/Components/Drawers/ActiveItemsDrawer.cs
+++ b/ProjectGagSpeak/UI/Components/Drawers/ActiveItemsDrawer.cs
@@ -328,6 +328,8 @@ public class ActiveItemsDrawer
                 });
             }
         }
+        if (_restraintItem.DrawPopup($"##RestraintSetSelector", data.Identifier, ImGui.GetContentRegionAvail().X * .90f, drawPos))
+            RestraintComboChanged(data.Identifier);
     }
 
     public void UnlockItemGroup(int slotIdx, ActiveGagSlot data)


### PR DESCRIPTION
This pull request introduces a missing `DrawPopup` method call, enabling the ability to switch active restraint sets directly without requiring them to be taken off first.