### PR TITLE
Implement the ability to clear a user's nickname

### DIFF
--- a/ProjectGagSpeak/DynamicDrawSystem/Drawers/WhitelistDrawer.cs
+++ b/ProjectGagSpeak/DynamicDrawSystem/Drawers/WhitelistDrawer.cs
@@ -220,7 +220,10 @@ public sealed class WhitelistDrawer : DynamicDrawer<Kinkster>
         ImGui.SetNextItemWidth(width);
         if (ImGui.InputTextWithHint($"##{leaf.FullPath}-nick", "Give a nickname..", ref _cache.NameEditStr, 45, ITFlags.EnterReturnsTrue))
         {
-            _nicks.SetNickname(leaf.Data.UserData.UID, _cache.NameEditStr);
+            if (!_cache.NameEditStr.IsNullOrWhitespace())
+                _nicks.SetNickname(leaf.Data.UserData.UID, _cache.NameEditStr);
+            else
+                _nicks.ClearNickname(leaf.Data.UserData.UID);
             _cache.RenamingNode = null;
         }
         if (ImGui.IsItemClicked(ImGuiMouseButton.Right))
@@ -393,4 +396,3 @@ public sealed class WhitelistDrawer : DynamicDrawer<Kinkster>
     }
     #endregion Utility
 }
-

--- a/ProjectGagSpeak/PlayerClient/Configs/NicksConfig.cs
+++ b/ProjectGagSpeak/PlayerClient/Configs/NicksConfig.cs
@@ -100,12 +100,12 @@ public class NicksConfig : IHybridSavable
         Save();
     }
 
-    public void ClearNickname(string userDataUID)
+    public void ClearNickname(string uid)
     {
-        if (userDataUID.IsNullOrWhitespace())
-            throw new ArgumentException("UserDataUID cannot be null or empty.");
+        if (uid.IsNullOrWhitespace())
+            throw new ArgumentException("uid cannot be null or empty.");
 
-        Current.Nicknames.Remove(userDataUID);
+        Current.Nicknames.Remove(uid);
         Save();
     }
 }

--- a/ProjectGagSpeak/PlayerClient/Configs/NicksConfig.cs
+++ b/ProjectGagSpeak/PlayerClient/Configs/NicksConfig.cs
@@ -86,7 +86,7 @@ public class NicksConfig : IHybridSavable
         => Current.Nicknames.TryGetValue(uid, out var n) && n is { Length: > 0 } ? n : null;
 
 
-    /// <summary> 
+    /// <summary>
     ///     Set a nickname for a user identifier.
     /// </summary>
     /// <param name="uid">the user identifier</param>
@@ -97,6 +97,15 @@ public class NicksConfig : IHybridSavable
             return;
 
         Current.Nicknames[uid] = nickname;
+        Save();
+    }
+
+    public void ClearNickname(string userDataUID)
+    {
+        if (userDataUID.IsNullOrWhitespace())
+            throw new ArgumentException("UserDataUID cannot be null or empty.");
+
+        Current.Nicknames.Remove(userDataUID);
         Save();
     }
 }


### PR DESCRIPTION
When the nickname edit field result is an empty string or a string containing only whitespace, remove the user's nickname entry from the list instead of saving it as nothing.