### PR TITLE
fix: defer expiry processing during zoning

### DIFF
--- a/ProjectGagSpeak/Services/AutoUnlockService.cs
+++ b/ProjectGagSpeak/Services/AutoUnlockService.cs
@@ -111,6 +111,11 @@ public sealed class AutoUnlockService : BackgroundService
     {
         if (!MainHub.IsConnected)
             return;
+        
+        // Defer expiry processing while zoning, as Glamourer IPC calls are dropped during transitions
+        if (PlayerData.IsZoning || !PlayerData.Available)
+            return;
+        
         // remove the stopwatch if it becomes excessive.
         var sw = Stopwatch.StartNew();
         await Task.WhenAll(


### PR DESCRIPTION
Since GlamourerIPC calls to setting item slots and meta data states are blocked while Zoning, we now wait until the player is done zoning to process their timers.

~~I did some basic testing with this change and it seems to work as expected. I would like to test a bit longer or get some feedback on if this will break anything since it will no longer do any unlock processing during a zone transition.~~

~~If this looks good, I'm okay with it being switched from draft to a normal PR without finishing my own tests.~~