### PR TITLE
fix: restraint trigger enable not applying visuals

### DIFF
--- a/ProjectGagSpeak/Triggers/ReactionDistributor.cs
+++ b/ProjectGagSpeak/Triggers/ReactionDistributor.cs
@@ -381,7 +381,7 @@ public class ReactionDistributor
                 Identifier = act.RestrictionId,
                 Enabler = enactor ?? MainHub.UID
             };
-            return await _selfBondage.DoSelfRestraintResult(setData, DataUpdateType.Applied).ConfigureAwait(false);
+            return await _selfBondage.DoSelfRestraintResult(setData, DataUpdateType.Swapped).ConfigureAwait(false);
         }
         else if (act.NewState is NewState.Locked)
         {


### PR DESCRIPTION
fixed issue where if you had a restraint equipped, because it would set the restraint you would never get the visual update.