### PR TITLE
fix: multiple triggers on same action not firing

### DIFF
--- a/ProjectGagSpeak/Triggers/Handlers/TriggerHandler.cs
+++ b/ProjectGagSpeak/Triggers/Handlers/TriggerHandler.cs
@@ -396,7 +396,6 @@ public class TriggerHandler : DisposableMediatorSubscriberBase
                 if (await _processor.HandleActionAsync(trigger.InvokableAction, enactor).ConfigureAwait(false))
                 {
                     GagspeakEventManager.AchievementEvent(UnlocksEvent.TriggerFired);
-                    break;
                 }
             }
             else
@@ -405,7 +404,6 @@ public class TriggerHandler : DisposableMediatorSubscriberBase
                 if (_processor.HandleAction(trigger.InvokableAction))
                 {
                     GagspeakEventManager.AchievementEvent(UnlocksEvent.TriggerFired);
-                    break;
                 }
             }
         }


### PR DESCRIPTION
Removed break statement after trigger handling to prevent issue where only one trigger could be processed ever. This will ensure all triggers are processed correctly.