### PR TITLE
feat: Added percent-chance-based firing mechanism for SpellActionTriggers

### DIFF
--- a/ProjectGagSpeak/State/_Models/Triggers/SpellActionTrigger.cs
+++ b/ProjectGagSpeak/State/_Models/Triggers/SpellActionTrigger.cs
@@ -29,6 +29,11 @@ public class SpellActionTrigger : Trigger, IThresholdContainer
     public int ThresholdMinValue { get; set; } = -1;
     public int ThresholdMaxValue { get; set; } = 10000000;
 
+    // If true, the trigger fires on a random % chance instead of a damage threshold.
+    public bool UsePercentChance { get; set; } = false;
+    // The % chance (0-100) the trigger fires when UsePercentChance is true.
+    public int PercentChance { get; set; } = 100;
+
     public SpellActionTrigger()
     { }
 
@@ -46,6 +51,8 @@ public class SpellActionTrigger : Trigger, IThresholdContainer
         StoredActions = new Dictionary<JobType, List<uint>>(other.StoredActions);
         ThresholdMinValue = other.ThresholdMinValue;
         ThresholdMaxValue = other.ThresholdMaxValue;
+        UsePercentChance = other.UsePercentChance;
+        PercentChance = other.PercentChance;
     }
 
     public override SpellActionTrigger Clone(bool keepId) => new SpellActionTrigger(this, keepId);
@@ -66,5 +73,7 @@ public class SpellActionTrigger : Trigger, IThresholdContainer
         StoredActions = new Dictionary<JobType, List<uint>>(sat.StoredActions);
         ThresholdMinValue = sat.ThresholdMinValue;
         ThresholdMaxValue = sat.ThresholdMaxValue;
+        UsePercentChance = sat.UsePercentChance;
+        PercentChance = sat.PercentChance;
     }
 }

--- a/ProjectGagSpeak/Triggers/Handlers/TriggerHandler.cs
+++ b/ProjectGagSpeak/Triggers/Handlers/TriggerHandler.cs
@@ -502,11 +502,23 @@ public class TriggerHandler : DisposableMediatorSubscriberBase
                 LimitedActionEffectType.BlockedDamage or
                 LimitedActionEffectType.ParriedDamage;
 
-            if (isDamageRelated && !IsDamageWithinThreshold(actEff.Damage, trigger.ThresholdMinValue, trigger.ThresholdMaxValue))
+            if (isDamageRelated)
             {
-                Logger.LogTrace($"Was ActionKind [{actEff.Type}], but its damage ({actEff.Damage}) wasn't " +
-                    $"between ({trigger.ThresholdMinValue}) & ({trigger.ThresholdMaxValue})", LoggerType.Triggers);
-                continue;
+                if (trigger.UsePercentChance)
+                {
+                    var roll = Random.Shared.Next(100);
+                    if (roll >= trigger.PercentChance)
+                    {
+                        Logger.LogTrace($"Percent-chance roll failed ({roll} >= {trigger.PercentChance}%)", LoggerType.Triggers);
+                        continue;
+                    }
+                }
+                else if (!IsDamageWithinThreshold(actEff.Damage, trigger.ThresholdMinValue, trigger.ThresholdMaxValue))
+                {
+                    Logger.LogTrace($"Was ActionKind [{actEff.Type}], but its damage ({actEff.Damage}) wasn't " +
+                        $"between ({trigger.ThresholdMinValue}) & ({trigger.ThresholdMaxValue})", LoggerType.Triggers);
+                    continue;
+                }
             }
 
             // Execute trigger action if all conditions are met

--- a/ProjectGagSpeak/UI/Components/Drawers/DetectionDrawer.cs
+++ b/ProjectGagSpeak/UI/Components/Drawers/DetectionDrawer.cs
@@ -118,15 +118,24 @@ public sealed class DetectionDrawer : IDisposable
         if (trigger.ActionKind is not (LimitedActionEffectType.Miss or LimitedActionEffectType.Knockback or LimitedActionEffectType.Attract1))
         {
             CkGui.FramedIconText(FAI.BarsProgress);
-            var format = trigger.ActionKind is LimitedActionEffectType.Heal ? "HP" : "DPS";
+            if (trigger.UsePercentChance)
+            {
+                CkGui.TextFrameAlignedInline("On a");
+                CkGui.ColorTextFrameAlignedInline($"{trigger.PercentChance}%", ImGuiColors.TankBlue);
+                CkGui.TextFrameAlignedInline("chance.");
+            }
+            else
+            {
+                var format = trigger.ActionKind is LimitedActionEffectType.Heal ? "HP" : "DPS";
 
-            CkGui.TextFrameAlignedInline("Between");
-            CkGui.ColorTextFrameAlignedInline($"{trigger.ThresholdMinValue}{format}", ImGuiColors.TankBlue);
-            CkGui.AttachTooltip("The lowest HP that is \"In Range\".");
+                CkGui.TextFrameAlignedInline("Between");
+                CkGui.ColorTextFrameAlignedInline($"{trigger.ThresholdMinValue}{format}", ImGuiColors.TankBlue);
+                CkGui.AttachTooltip("The lowest HP that is \"In Range\".");
 
-            CkGui.TextFrameAlignedInline("and");
-            CkGui.ColorTextFrameAlignedInline($"{trigger.ThresholdMaxValue}{format}", ImGuiColors.TankBlue);
-            CkGui.AttachTooltip("The highest HP that is \"In Range\".");
+                CkGui.TextFrameAlignedInline("and");
+                CkGui.ColorTextFrameAlignedInline($"{trigger.ThresholdMaxValue}{format}", ImGuiColors.TankBlue);
+                CkGui.AttachTooltip("The highest HP that is \"In Range\".");
+            }
         }
 
         if (trigger.IsGenericDetection)
@@ -214,23 +223,39 @@ public sealed class DetectionDrawer : IDisposable
 
         if (trigger.ActionKind is not (LimitedActionEffectType.Miss or LimitedActionEffectType.Knockback or LimitedActionEffectType.Attract1))
         {
-            var formatPost = trigger.ActionKind is LimitedActionEffectType.Heal ? "HP" : "DPS";
+            var pctRef = trigger.UsePercentChance;
+            if (ImGui.Checkbox("Use % Chance Instead##UsePercentChance", ref pctRef))
+                trigger.UsePercentChance = pctRef;
+            CkGui.AttachTooltip("If the trigger fires on a random % chance, or on a damage/heal threshold.");
+
             CkGui.FramedIconText(FAI.BarsProgress);
             ImUtf8.SameLineInner();
-            var dragW = (ImGui.GetContentRegionAvail().X - ImUtf8.ItemInnerSpacing.X) / 2;
-            var minRef = trigger.ThresholdMinValue;
-            var maxRef = trigger.ThresholdMaxValue;
+            if (trigger.UsePercentChance)
+            {
+                var chanceRef = trigger.PercentChance;
+                ImGui.SetNextItemWidth(ImGui.GetContentRegionAvail().X);
+                if (ImGui.DragInt("##PercentChanceSlider", ref chanceRef, 1.0f, 0, 100, "%d%% Chance"))
+                    trigger.PercentChance = Math.Clamp(chanceRef, 0, 100);
+                CkGui.AttachTooltip("The % chance the trigger fires when its action is detected.", ImGuiColors.TankBlue);
+            }
+            else
+            {
+                var formatPost = trigger.ActionKind is LimitedActionEffectType.Heal ? "HP" : "DPS";
+                var dragW = (ImGui.GetContentRegionAvail().X - ImUtf8.ItemInnerSpacing.X) / 2;
+                var minRef = trigger.ThresholdMinValue;
+                var maxRef = trigger.ThresholdMaxValue;
 
-            ImGui.SetNextItemWidth(dragW);
-            if (ImGui.DragInt("##MinThresSlider", ref minRef, 10.0f, -1, 1000000, $"Min. %d{formatPost}"))
-                trigger.ThresholdMinValue = minRef;
-            CkGui.AttachTooltip("The lowest HP that is --COL--\"In Range\"--COL--.", ImGuiColors.TankBlue);
+                ImGui.SetNextItemWidth(dragW);
+                if (ImGui.DragInt("##MinThresSlider", ref minRef, 10.0f, -1, 1000000, $"Min. %d{formatPost}"))
+                    trigger.ThresholdMinValue = minRef;
+                CkGui.AttachTooltip("The lowest HP that is --COL--\"In Range\"--COL--.", ImGuiColors.TankBlue);
 
-            ImUtf8.SameLineInner();
-            ImGui.SetNextItemWidth(dragW);
-            if (ImGui.DragInt("##MaxThresSlider", ref maxRef, 10.0f, minRef, 1000000, $"Max. %d{formatPost}"))
-                trigger.ThresholdMaxValue = maxRef;
-            CkGui.AttachTooltip("The highest HP that is --COL--\"In Range\"--COL--.", ImGuiColors.TankBlue);
+                ImUtf8.SameLineInner();
+                ImGui.SetNextItemWidth(dragW);
+                if (ImGui.DragInt("##MaxThresSlider", ref maxRef, 10.0f, minRef, 1000000, $"Max. %d{formatPost}"))
+                    trigger.ThresholdMaxValue = maxRef;
+                CkGui.AttachTooltip("The highest HP that is --COL--\"In Range\"--COL--.", ImGuiColors.TankBlue);
+            }
         }
 
         // DetectableActions - This filter display allows you to append certain jobs and actions you want the trigger to qualify for.


### PR DESCRIPTION
This change introduces a new option for triggers to fire based on a configurable random percentage chance, as an alternative to damage thresholds.

I had some ideas for triggers that I wanted so have based on a percent chance but there was no way (from what I saw) to do that. So this is what I came up with.