### PR TITLE
QoL: Update sorting for some lists visually shown

### DIFF
--- a/ProjectGagSpeak/CustomCombos/PairCombos/PairRestraintCombo.cs
+++ b/ProjectGagSpeak/CustomCombos/PairCombos/PairRestraintCombo.cs
@@ -21,7 +21,7 @@ public sealed class PairRestraintCombo : CkFilterComboButton<KinksterRestraint>
     private LayerFlagsWidget _layersHelper = new(FAI.LayerGroup, "RestraintLayers", "Select Layers..");
 
     public PairRestraintCombo(ILogger log, MainHub hub, Kinkster pair, Action postButtonPress)
-        : base(() => [ ..pair.LightCache.Restraints.Values ], log)
+        : base(() => [ ..pair.LightCache.Restraints.Values.OrderBy(x => x.Label) ], log)
     {
         _mainHub = hub;
         _pairRef = pair;

--- a/ProjectGagSpeak/UI/Modules/CursedLoot/LootPoolTab.cs
+++ b/ProjectGagSpeak/UI/Modules/CursedLoot/LootPoolTab.cs
@@ -67,7 +67,7 @@ public class LootPoolTab : IFancyTab
                 return;
 
             using var padding = ImRaii.PushStyle(ImGuiStyleVar.WindowPadding, new Vector2(ImUtf8.ItemInnerSpacing.X * .5f, 0));
-            foreach (var inactiveLoot in itemsOutOfPool)
+            foreach (var inactiveLoot in itemsOutOfPool.OrderBy(i => i.Label, StringComparer.OrdinalIgnoreCase))
                 DrawLootItem(inactiveLoot, _.InnerRegion.X);
         }
     }
@@ -84,7 +84,7 @@ public class LootPoolTab : IFancyTab
                 return;
 
             using var padding = ImRaii.PushStyle(ImGuiStyleVar.WindowPadding, new Vector2(ImUtf8.ItemInnerSpacing.X * .5f, 0));
-            foreach (var inactiveLoot in itemsInPool)
+            foreach (var inactiveLoot in itemsInPool.OrderBy(i => i.Label, StringComparer.OrdinalIgnoreCase))
                 DrawLootItem(inactiveLoot, _.InnerRegion.X);
         }
     }


### PR DESCRIPTION
Sort cursed loot pools (inactive and active) and restraints (interactions panel drop down) by label alphabetically.