### PR TITLE
fix: achievement event firing for hardcore state change enactor

### DIFF
--- a/ProjectGagSpeak/WebAPI/Hubs/MainHub.ApiCallbacks.cs
+++ b/ProjectGagSpeak/WebAPI/Hubs/MainHub.ApiCallbacks.cs
@@ -4,6 +4,7 @@ using GagSpeak.Interop.Helpers;
 using GagSpeak.Services.Mediator;
 using GagSpeak.State.Caches;
 using GagspeakAPI.Data;
+using GagspeakAPI.Extensions;
 using GagspeakAPI.Dto.VibeRoom;
 using GagspeakAPI.Network;
 using Microsoft.AspNetCore.SignalR.Client;
@@ -323,6 +324,7 @@ public partial class MainHub
         {
             Logger.LogDebug($"[OTHER-PERM-CHANGE]: {dto}", LoggerType.Callbacks);
             Generic.Safe(() => _kinksters.StateChangeHardcore(dto.Target, dto.Enactor, dto.Changed, dto.NewData));
+            GagspeakEventManager.AchievementEvent(UnlocksEvent.HardcoreAction, dto.Changed, dto.NewData.IsEnabled(dto.Changed), dto.Enactor, dto.Target.UID);
         }
         return Task.CompletedTask;
 


### PR DESCRIPTION
Currently the hardcore action achievement event is only fired if you are the target of the change. I updated the callback to make sure that the achievement event is fired when you, the enactor, makes a change to another pair.

This fixes All The Collars Of The Rainbow and starts Come Follow Along Now / The Leash of Your Worries achievement tracking