### PR TITLE
feat: integrate Lifestream address book combo for confinement configuration

### DIFF
--- a/ProjectGagSpeak/CustomCombos/AddressBookCombo.cs
+++ b/ProjectGagSpeak/CustomCombos/AddressBookCombo.cs
@@ -1,0 +1,43 @@
+using CkCommons;
+using Dalamud.Bindings.ImGui;
+using Penumbra.GameData.Structs;
+
+namespace GagSpeak.CustomCombos;
+
+/// <summary> A combo for selecting an entry from the Lifestream address book. </summary>
+public sealed class AddressBookCombo : CkFilterComboCache<AddressBookEntryTuple>
+{
+    public AddressBookCombo(ILogger log, Func<IReadOnlyList<AddressBookEntryTuple>> generator)
+        : base(() => generator().OrderBy(DisplayString, StringComparer.OrdinalIgnoreCase).ToList(), log)
+    { }
+
+    private static string Label(AddressBookEntryTuple obj)
+        => obj.AliasEnabled && !string.IsNullOrEmpty(obj.Alias) ? obj.Alias
+        : !string.IsNullOrEmpty(obj.Name) ? obj.Name : string.Empty;
+
+    public static string DisplayString(AddressBookEntryTuple obj)
+    {
+        var label = Label(obj);
+        return string.IsNullOrEmpty(label) ? AddressString(obj) : $"{label}  |  {AddressString(obj)}";
+    }
+
+    protected override string ToString(AddressBookEntryTuple obj)
+        => DisplayString(obj);
+
+    /// <summary> Builds the readable address: house = world, city, ward, plot | apartment = world, city, ward, apartment. </summary>
+    public static string AddressString(AddressBookEntryTuple obj)
+    {
+        var world = ItemSvc.WorldData.TryGetValue(new WorldId((ushort)obj.World), out var w) ? w : "Unknown World";
+        var city = GameDataHelp.ResidentialNames.TryGetValue((ResidentialAetheryteKind)obj.City, out var c) ? c : "Unknown City";
+        var unit = (PropertyType)obj.PropertyType is PropertyType.Apartment
+            ? $"Apt {obj.Apartment}" : $"Plot {obj.Plot}";
+        return $"{world}, {city}, Ward {obj.Ward}, {unit}";
+    }
+
+    /// <summary> Simple draw invoke. </summary>
+    public bool Draw(string preview, float width, CFlags flags = CFlags.None)
+    {
+        InnerWidth = width * 1.3f;
+        return Draw("##addressBookCombo", preview, string.Empty, width, ImGui.GetTextLineHeightWithSpacing(), flags);
+    }
+}

--- a/ProjectGagSpeak/Interop/Ipc/IpcCallerLifestream.cs
+++ b/ProjectGagSpeak/Interop/Ipc/IpcCallerLifestream.cs
@@ -12,6 +12,7 @@ public sealed class IpcCallerLifestream : IIpcCaller
     // API Getters
     private readonly ICallGateSubscriber<AddressBookEntryTuple, bool> GetIsAtAddress;
     private readonly ICallGateSubscriber<bool>                        GetIsBusy;
+    private readonly ICallGateSubscriber<List<AddressBookEntryTuple>> GetAddressBookList;
 
     // API Enactors
     // IPC Function Delegates (calls that instruct Lifestream to do something)
@@ -27,6 +28,8 @@ public sealed class IpcCallerLifestream : IIpcCaller
 
         TravelToAddress = Svc.PluginInterface.GetIpcSubscriber<AddressBookEntryTuple, object>("Lifestream.GoToHousingAddress");
         AbortTask = Svc.PluginInterface.GetIpcSubscriber<object>("Lifestream.Abort");
+
+        GetAddressBookList = Svc.PluginInterface.GetIpcSubscriber<List<AddressBookEntryTuple>>("Lifestream.GetAddressBookEntries");
 
         // subscribe to event.
         OnHouseEnterError.Subscribe(OnErrorEnteringHouse);
@@ -92,5 +95,14 @@ public sealed class IpcCallerLifestream : IIpcCaller
 
         // invoke the action for the address.
         TravelToAddress.InvokeAction(address);
+    }
+
+    /// <summary> Gets the address book list. </summary>
+    public List<AddressBookEntryTuple>? GetAddressList()
+    {
+        if (!APIAvailable)
+            return null;
+
+        return GetAddressBookList.InvokeFunc();
     }
 }

--- a/ProjectGagSpeak/UI/MainUi/SidePanel/SidePanelKinkster/SidePanelPair.Hardcore.cs
+++ b/ProjectGagSpeak/UI/MainUi/SidePanel/SidePanelKinkster/SidePanelPair.Hardcore.cs
@@ -5,6 +5,9 @@ using CkCommons.Raii;
 using Dalamud.Bindings.ImGui;
 using Dalamud.Interface.Colors;
 using Dalamud.Interface.Utility.Raii;
+using GagSpeak.CustomCombos;
+using GagSpeak.Interop;
+using GagSpeak.Interop.Helpers;
 using GagSpeak.Kinksters;
 using GagSpeak.Services;
 using GagSpeak.Watchers;
@@ -56,7 +59,9 @@ public partial class SidePanelPair
         var confinementAllowed = k.PairPerms.AllowIndoorConfinement && hc.CanChange(HcAttribute.Confinement, MainHub.UID);
         var confinementTT = confinementActive ? $"End {dispName}'s confinement period." : $"Confine {dispName} indoors.";
         DrawColoredExpander(InteractionType.Confinement, confinementInfo.Item1, confinementInfo.Item2, confinementActive, !confinementAllowed, confinementTT);
-        UniqueHcChild(InteractionType.Confinement, confinementActive, CkStyle.GetFrameRowsHeight(4).AddWinPadY(), () =>
+        // Confine child = timer row (1) + address config rows. Address config grows by a row for the Lifestream toggle when it is available.
+        var confineRows = AddressConfigRows(cache) + 1;
+        UniqueHcChild(InteractionType.Confinement, confinementActive, CkStyle.GetFrameRowsHeight(confineRows).AddWinPadY(), () =>
         {
             DrawTimerButtonRow(InteractionType.Confinement, ref cache.ConfinementTimer, "Confine", !confinementAllowed);
             DrawAddressConfig(cache, k, dispName, width);
@@ -235,9 +240,37 @@ public partial class SidePanelPair
         }
     }
 
+    // Rows the AddressConfig child needs. Default (no Lifestream) = 3. With Lifestream a toggle row is added;
+    // when that toggle picks the address book, the manual slider rows collapse away.
+    private static int AddressConfigRows(KinksterInfoCache cache)
+        => !IpcCallerLifestream.APIAvailable ? 3 : (cache.UseLifestreamAddress ? 1 : 4);
+
     private void DrawAddressConfig(KinksterInfoCache cache, Kinkster k, string dispName, float width)
     {
-        using var c = CkRaii.FramedChildPaddedWH("##AddressConfig", new(width, CkStyle.GetFrameRowsHeight(3).AddWinPadY()), 0, GsCol.VibrantPink.Uint());
+        using var c = CkRaii.FramedChildPaddedWH("##AddressConfig", new(width, CkStyle.GetFrameRowsHeight(AddressConfigRows(cache)).AddWinPadY()), 0, GsCol.VibrantPink.Uint());
+
+        // When Lifestream is installed, offer pulling a saved address from its address book instead of the manual sliders.
+        if (IpcCallerLifestream.APIAvailable)
+        {
+            ImGui.Checkbox("##UseLifestreamAddr", ref cache.UseLifestreamAddress);
+            CkGui.AttachTooltip("Pick a saved address from your Lifestream address book instead of entering it manually.");
+
+            ImUtf8.SameLineInner();
+            using (ImRaii.Disabled(!cache.UseLifestreamAddress))
+            {
+                // Default AddressBookEntry leaves World at ushort.MaxValue; treat that as "nothing picked yet".
+                var preview = cache.Address.World == ushort.MaxValue
+                    ? "Select an Address.."
+                    : AddressBookCombo.DisplayString(cache.Address.AsTuple());
+                if (_addressBook.Draw(preview, ImGui.GetContentRegionAvail().X, CFlags.NoArrowButton) && _addressBook.Current is { } picked)
+                    cache.Address = AddressBookEntry.FromTuple(picked);
+            }
+            CkGui.AttachTooltip($"The saved Lifestream address {dispName} will be confined to.");
+
+            // When using the address book, all manual fields are sourced from the picked entry, so hide them.
+            if (cache.UseLifestreamAddress)
+                return;
+        }
 
         CkGui.FramedIconText(FAI.Home);
         ImUtf8.SameLineInner();

--- a/ProjectGagSpeak/UI/MainUi/SidePanel/SidePanelKinkster/SidePanelPair.cs
+++ b/ProjectGagSpeak/UI/MainUi/SidePanel/SidePanelKinkster/SidePanelPair.cs
@@ -5,6 +5,8 @@ using CkCommons.Raii;
 using Dalamud.Bindings.ImGui;
 using Dalamud.Interface.Colors;
 using Dalamud.Interface.Utility.Raii;
+using GagSpeak.CustomCombos;
+using GagSpeak.Interop;
 using GagSpeak.Kinksters;
 using GagSpeak.PlayerClient;
 using GagSpeak.Services;
@@ -26,13 +28,15 @@ public partial class SidePanelPair
     private readonly KinksterManager _kinksters;
     private readonly SidePanelService _service;
     private readonly PiShockProvider _shockies;
+    private readonly IpcCallerLifestream _lifestream;
+    private readonly AddressBookCombo _addressBook;
 
     private Dictionary<KPID, string> _timespanCache = new();
     private static IconCheckboxEx EditAccessCheckbox = new(FAI.Pen, 0xFF00FF00, 0);
     private static IconCheckboxEx HardcoreCheckbox = new(FAI.UserLock, 0xFF00FF00, 0xFF0000FF);
 
     public SidePanelPair(ILogger<SidePanelPair> logger, GagspeakMediator mediator, MainHub hub,
-        KinksterManager kinksters, SidePanelService service, PiShockProvider shockies)
+        KinksterManager kinksters, SidePanelService service, PiShockProvider shockies, IpcCallerLifestream lifestream)
     {
         _logger = logger;
         _mediator = mediator;
@@ -40,6 +44,8 @@ public partial class SidePanelPair
         _kinksters = kinksters;
         _service = service;
         _shockies = shockies;
+        _lifestream = lifestream;
+        _addressBook = new AddressBookCombo(logger, () => _lifestream.GetAddressList() ?? new List<AddressBookEntryTuple>());
     }
 
     public void DrawClientPermissions(KinksterInfoCache cache, Kinkster kinkster, string dispName, float width)

--- a/ProjectGagSpeak/UI/MainUi/SidePanel/SidePanelService.cs
+++ b/ProjectGagSpeak/UI/MainUi/SidePanel/SidePanelService.cs
@@ -73,6 +73,7 @@ public class KinksterInfoCache : ISidePanelCache, IDisposable
 
     public string ConfinementTimer = string.Empty;
     public AddressBookEntry Address = new();
+    public bool UseLifestreamAddress = false;
 
     public string ImprisonTimer = string.Empty;
     public Vector3 ImprisonPos = Vector3.Zero;
@@ -198,6 +199,7 @@ public class KinksterInfoCache : ISidePanelCache, IDisposable
         EmoteId = 0;
         CyclePose = 0;
         Address = new AddressBookEntry();
+        UseLifestreamAddress = false;
         ImprisonPos = Vector3.Zero;
         ImprisonRadius = 1f;
         ApplyIntensity = 0;


### PR DESCRIPTION
Added support for selecting addresses from the Lifestream address book in the confinement panel, allowing users to pick saved addresses instead of manually configuring them. If lifestream isn't installed, it doesn't change anything. if it is, a new row in the menu was added to select from its address list.


_I got tired of having to look up addresses. Why not just request the saved list from life stream?_