### PR TITLE
fix: teleport offer confirmation handling while confined

### DIFF
--- a/ProjectGagSpeak/Localization/ForcedStayLang.cs
+++ b/ProjectGagSpeak/Localization/ForcedStayLang.cs
@@ -46,6 +46,8 @@ internal static class GsLang
     public static readonly string[] ConfirmHouseExit = [ "Leave the estate hall?", "Das Gebäude verlassen?"]; // yes | no option.
 
     public static readonly string[] ExitChambers = [ "Exit" ];
+    
+    public static readonly string[] ConfirmTeleportOffer = ["Accept Teleport to"]; // SelectString, option we want is below.
 
     public static readonly string[] DeepDungeonCoffer = [ "Treasure Coffer", "Schatztruhe" ];
 

--- a/ProjectGagSpeak/PlayerControl/Controllers/AutoPromptController.cs
+++ b/ProjectGagSpeak/PlayerControl/Controllers/AutoPromptController.cs
@@ -80,20 +80,26 @@ public sealed class AutoPromptController : DisposableMediatorSubscriberBase
         var baseAddon = (AtkUnitBase*)yesno;
 
         string[] nodesToDecline = [ ..GsLang.ConfirmHouseExit, ..GsLang.ConfirmChamberLeave ];
+        string[] nodesToDeclineContains = [ ..GsLang.ConfirmTeleportOffer ];
         string[] nodesToAccept = [ ..GsLang.ConfirmHouseEntrance ];
 
-        // Check for auto-no responces
-        if (HcTaskUtils.YesNoMatches(baseAddon, contains: false, nodesToDecline))
+        // Check for auto-no responses
+        if (HcTaskUtils.YesNoMatches(baseAddon, contains: false, nodesToDecline) || HcTaskUtils.YesNoMatches(baseAddon, contains: true, nodesToDeclineContains))
         {
-            // if addon is ready, check for validation to hit the yes button prior to pressing it.
-            if (yesno->NoButton is not null && !yesno->NoButton->IsEnabled)
+            var noButton = yesno->NoButton;
+            // if the addon is actually a Yes Wait No, then we need to find the No button.
+            if (yesno->AtkComponentButton238 is not null && yesno->AtkComponentButton238->ButtonTextNode->NodeText.ExtractText() == "No")
+                noButton = yesno->AtkComponentButton238;
+            
+            // if addon is ready, check for validation to hit the no button prior to pressing it.
+            if (noButton is not null && !noButton->IsEnabled)
             {
-                // forcibly enable the yes button through node flag manipulation.
+                // forcibly enable the no button through node flag manipulation.
                 Svc.Logger.Verbose($"{nameof(AddonSelectYesno)}: Force enabling [No]");
-                var flagsPtr = (ushort*)&yesno->NoButton->AtkComponentBase.OwnerNode->AtkResNode.NodeFlags;
+                var flagsPtr = (ushort*)&noButton->AtkComponentBase.OwnerNode->AtkResNode.NodeFlags;
                 *flagsPtr ^= 1 << 5; // Toggle the 5th bit to enable the button.
             }
-            HcTaskUtils.ClickButtonIfEnabled(baseAddon, yesno->NoButton);
+            HcTaskUtils.ClickButtonIfEnabled(baseAddon, noButton);
             return;
         }
 


### PR DESCRIPTION
Added teleport offer confirmation handling to the AutoPromptController
Updated the logic for selecting the no button (might be a better way to do this)

Teleport offers give 3 options to select but are considered a SelectYesNo add-on. The NoButton, in the class, actually points to the wait button. Since this is the case, I added a check to see if the 3rd button is actually No and to have it press that instead IF its "No"

I wasn't sure if this was an oversight for the confinement settings so I decided to fix this. If it is intended to allow teleport offers to be accepted, feel free to close this.