### PR TITLE
feat: cursed loot stat tracking

### DIFF
--- a/ProjectGagSpeak/Services/AutoUnlockService.cs
+++ b/ProjectGagSpeak/Services/AutoUnlockService.cs
@@ -180,6 +180,8 @@ public sealed class AutoUnlockService : BackgroundService
 
         foreach (var (gag, index) in gags.GagSlots.Select((slot, index) => (slot, index)))
         {
+            // Mimic padlocks belong to cursed loot gags, whose lifecycle is handled by CheckCursedLoot.
+            if (gag.Padlock is Padlocks.Mimic) continue;
             if (!gag.Padlock.IsTimerLock()) continue;
             if (!gag.HasTimerExpired()) continue;
 
@@ -335,6 +337,49 @@ public sealed class AutoUnlockService : BackgroundService
                 // was successful, so make sure to remove it from viausals and cache manager.
                 await _visuals.CursedItemRemoved(item.Identifier);
             }
+        }
+
+        // Free any gag slots still held by expired cursed loot gags.
+        await FreeExpiredCursedGagSlots().ConfigureAwait(false);
+    }
+
+    /// <summary>
+    ///     Unlocks and removes gag slots locked by an expired Mimic padlock once their cursed loot
+    ///     item is no longer applied. Runs after the loot expiry pass so the cursed visuals are
+    ///     already cleared, and retries on later ticks if a server push fails.
+    /// </summary>
+    private async Task FreeExpiredCursedGagSlots()
+    {
+        if (_gags.ServerGagData is not { } data)
+            return;
+
+        for (var layer = 0; layer < data.GagSlots.Length; layer++)
+        {
+            var slot = data.GagSlots[layer];
+            if (slot.Padlock is not Padlocks.Mimic || !slot.HasTimerExpired())
+                continue;
+
+            // leave the slot alone while its cursed loot item is still applied; the loot expiry pass handles that first.
+            if (_cursedLoot.Storage.AppliedLootUnsorted.OfType<CursedGagItem>().Any(c => c.RefItem?.GagType == slot.GagItem))
+                continue;
+
+            // capture the name now, the unlock & removal below mutate the slot.
+            var gagName = slot.GagItem.GagName();
+            _logger.LogInformation($"Freeing gag slot {layer} from expired cursed loot gag [{gagName}]", LoggerType.AutoUnlocks);
+            // unlock the mimic padlock first, the server will not remove a locked gag.
+            var unlockData = new ActiveGagSlot() with { Padlock = slot.Padlock, Password = slot.Password, PadlockAssigner = slot.PadlockAssigner };
+            if (await _dds.PushNewActiveGagSlot(layer, unlockData, DataUpdateType.Unlocked).ConfigureAwait(false) is null)
+                continue;
+            _gags.UnlockGag(layer, MainHub.UID);
+
+            // now remove the gag from the slot entirely.
+            if (await _dds.PushNewActiveGagSlot(layer, new ActiveGagSlot(), DataUpdateType.Removed).ConfigureAwait(false) is null)
+                continue;
+            // cursed gag visuals live in the cursed loot cache and were removed with the loot item,
+            // but clear the gag-keyed cache too in case this slot was cached as a normal gag.
+            if (_gags.RemoveGag(layer, MainHub.UID, out var visualItem))
+                await _cacheManager.RemoveGagItem(visualItem, layer);
+            _mediator.Publish(new EventMessage(new("Auto-Unlock", MainHub.UID, InteractionType.RemoveGag, $"Cursed Loot Gag [{gagName}] expired and was removed!")));
         }
     }
 

--- a/ProjectGagSpeak/Services/AutoUnlockService.cs
+++ b/ProjectGagSpeak/Services/AutoUnlockService.cs
@@ -318,8 +318,9 @@ public sealed class AutoUnlockService : BackgroundService
 
             _logger.LogInformation($"CursedLoot Item [{item.Label}] Timer Expired!", LoggerType.AutoUnlocks);
 
-            // store backup state.
-            var backup = item;
+            // store backup state. (CursedItem is a reference type, so copy the values off it, not the item itself)
+            var appliedBackup = item.AppliedTime;
+            var releaseBackup = item.ReleaseTime;
             // Temporarily update the changes locally, to prevent excess Auto-unlock calls.
             item.AppliedTime = DateTimeOffset.MinValue;
             item.ReleaseTime = DateTimeOffset.MinValue;
@@ -328,8 +329,8 @@ public sealed class AutoUnlockService : BackgroundService
             if (await _dds.PushActiveCursedLoot(_cursedLoot.Storage.AppliedLootIds.ToList(), item.Identifier, null).ConfigureAwait(false) is null)
             {
                 // Revert the values to prevent the update and trigger it again later. This helps to prevent false achievement triggering.
-                item.AppliedTime = backup.AppliedTime;
-                item.ReleaseTime = backup.ReleaseTime;
+                item.AppliedTime = appliedBackup;
+                item.ReleaseTime = releaseBackup;
                 _cursedLoot.ForceSave();
             }
             else

--- a/ProjectGagSpeak/State/Handlers/CallbackHandler.cs
+++ b/ProjectGagSpeak/State/Handlers/CallbackHandler.cs
@@ -29,6 +29,7 @@ public sealed class CallbackHandler : DisposableMediatorSubscriberBase
     private readonly CursedLootManager _cursedLoot;
     private readonly PuppeteerManager _puppeteer;
     private readonly CacheStateManager _cacheManager;
+    private readonly MainConfig _config;
 
     public CallbackHandler(
         ILogger<CallbackHandler> logger,
@@ -56,6 +57,7 @@ public sealed class CallbackHandler : DisposableMediatorSubscriberBase
         _puppeteer = aliasManager;
         _cacheManager = cacheManager;
         _provider = provider;
+        _config = config;
     }
 
     private bool PostActionMsg(string enactor, InteractionType type, string message)
@@ -370,7 +372,7 @@ public sealed class CallbackHandler : DisposableMediatorSubscriberBase
 
         // apply the gag, and it's visual updates.
         if (_gags.ApplyGag(layer, newData.GagItem, "Mimic", out var gagItem))
-            await _cacheManager.AddGagItem(gagItem, layer, "Mimic");
+            await _cacheManager.AddGagItem(gagItem, layer, "Mimic", _config.Current.CursedItemsApplyTraits && item.ApplyTraits);
 
         // Lock it immediately.
         _gags.LockGag(layer, newData, "Mimic");

--- a/ProjectGagSpeak/State/Handlers/CallbackHandler.cs
+++ b/ProjectGagSpeak/State/Handlers/CallbackHandler.cs
@@ -353,7 +353,7 @@ public sealed class CallbackHandler : DisposableMediatorSubscriberBase
             return;
 
         // Mark the loot as applied, so it shows up in the applied loot tab like the other cursed loot types.
-        _cursedLoot.ActivateItem(item, endTime);
+        _cursedLoot.ActivateItem(item, endTime, newEncounter: true);
 
         // new data for cursed item. (this is the same as what was sent over the server, so it syncs)
         var newData = new ActiveGagSlot
@@ -391,7 +391,7 @@ public sealed class CallbackHandler : DisposableMediatorSubscriberBase
         if (!MainHub.IsConnectionDataSynced)
             return;
 
-        _cursedLoot.ActivateItem(item, endTime);
+        _cursedLoot.ActivateItem(item, endTime, newEncounter: true);
         // now we need to update the equivalent visual data.
         if (_restrictions.ApplyCursedItem(item, out var layer))
             await _cacheManager.AddCursedItem(item, layer);

--- a/ProjectGagSpeak/State/Handlers/CallbackHandler.cs
+++ b/ProjectGagSpeak/State/Handlers/CallbackHandler.cs
@@ -352,10 +352,8 @@ public sealed class CallbackHandler : DisposableMediatorSubscriberBase
         if (!MainHub.IsConnectionDataSynced)
             return;
 
-        // Update the release time inside of the cursed loot manager. 
-        item.AppliedTime = DateTimeOffset.UtcNow;
-        item.ReleaseTime = endTime;
-        _cursedLoot.ForceSave();
+        // Mark the loot as applied, so it shows up in the applied loot tab like the other cursed loot types.
+        _cursedLoot.ActivateItem(item, endTime);
 
         // new data for cursed item. (this is the same as what was sent over the server, so it syncs)
         var newData = new ActiveGagSlot
@@ -368,13 +366,12 @@ public sealed class CallbackHandler : DisposableMediatorSubscriberBase
             PadlockAssigner = "Mimic"
         };
 
-        // apply the gag, and it's visual updates.
-        if (_gags.ApplyGag(layer, newData.GagItem, "Mimic", out var gagItem))
-            await _cacheManager.AddGagItem(gagItem, layer, "Mimic");
-
-        // Lock it immediately.
+        // Mirror the server's gag slot state, and lock it immediately.
+        _gags.ApplyGag(layer, newData.GagItem, "Mimic", out _);
         _gags.LockGag(layer, newData, "Mimic");
-        // the apply gag function already handled all of the visual cache application for us, so we can return here.
+
+        // Cache the visuals through the cursed loot system instead of the gag system.
+        await _cacheManager.AddCursedGagItem(item, layer);
 
         Logger.LogInformation($"Cursed Loot Applied & Locked!", LoggerType.CursedItems);
         Svc.Chat.PrintError(new SeStringBuilder()
@@ -420,6 +417,14 @@ public sealed class CallbackHandler : DisposableMediatorSubscriberBase
             // remove it, and then remove it from the visuals if valid.
             if (_restrictions.RemoveCursedItem(restriction, out var layer))
                 await _cacheManager.RemoveCursedItem(restriction, layer);
+        }
+        else if (item is CursedGagItem cursedGag && _gags.ServerGagData is { } gagData)
+        {
+            // locate the gag slot the cursed gag occupies and clear its cursed visuals.
+            // (freeing the slot itself is pushed to the server by the auto-unlock service)
+            var layer = Array.FindIndex(gagData.GagSlots, s => s.Enabler == "Mimic" && s.GagItem == cursedGag.RefItem.GagType);
+            if (layer != -1)
+                await _cacheManager.RemoveCursedGagItem(cursedGag, layer);
         }
 
         Logger.LogInformation($"Cursed Loot Removed!", LoggerType.CursedItems);

--- a/ProjectGagSpeak/State/Handlers/CallbackHandler.cs
+++ b/ProjectGagSpeak/State/Handlers/CallbackHandler.cs
@@ -29,7 +29,6 @@ public sealed class CallbackHandler : DisposableMediatorSubscriberBase
     private readonly CursedLootManager _cursedLoot;
     private readonly PuppeteerManager _puppeteer;
     private readonly CacheStateManager _cacheManager;
-    private readonly MainConfig _config;
 
     public CallbackHandler(
         ILogger<CallbackHandler> logger,
@@ -57,7 +56,6 @@ public sealed class CallbackHandler : DisposableMediatorSubscriberBase
         _puppeteer = aliasManager;
         _cacheManager = cacheManager;
         _provider = provider;
-        _config = config;
     }
 
     private bool PostActionMsg(string enactor, InteractionType type, string message)
@@ -372,7 +370,7 @@ public sealed class CallbackHandler : DisposableMediatorSubscriberBase
 
         // apply the gag, and it's visual updates.
         if (_gags.ApplyGag(layer, newData.GagItem, "Mimic", out var gagItem))
-            await _cacheManager.AddGagItem(gagItem, layer, "Mimic", _config.Current.CursedItemsApplyTraits && item.ApplyTraits);
+            await _cacheManager.AddGagItem(gagItem, layer, "Mimic");
 
         // Lock it immediately.
         _gags.LockGag(layer, newData, "Mimic");

--- a/ProjectGagSpeak/State/Handlers/LootHandler.cs
+++ b/ProjectGagSpeak/State/Handlers/LootHandler.cs
@@ -136,7 +136,7 @@ public sealed class LootHandler
     {
         // Return if there is nothing to apply.
         var validItems = _manager.Storage.ActiveUnappliedLoot;
-        if (validItems.Count <= 0)
+        if (validItems.Count <= 0 || _manager.LockChance <= 0)
             return;
 
         // run our first roll, return if not in range.

--- a/ProjectGagSpeak/State/Handlers/LootHandler.cs
+++ b/ProjectGagSpeak/State/Handlers/LootHandler.cs
@@ -134,16 +134,19 @@ public sealed class LootHandler
 
     private async Task ApplyCursedLoot()
     {
+        // Return if there is nothing to apply.
+        var validItems = _manager.Storage.ActiveUnappliedLoot;
+        if (validItems.Count <= 0)
+            return;
+
         // run our first roll, return if not in range.
         var roll = new Random().Next(1, 101); // 0,101 will return 0 to 100 inclusive, so 1,101 is what you want for 1-100 inclusive (and for a config value of 5% to not actually be 5.9%[6/101] chance)
         _logger.LogDebug($"Cursed Loot Roll: {roll} vs Chance: {_manager.LockChance}", LoggerType.CursedItems);
         if (roll > _manager.LockChance)
+        {
+            _manager.RecordMimicEvaded();
             return;
-
-        // Return if there is nothing to apply.to.
-        var validItems = _manager.Storage.ActiveUnappliedLoot;
-        if (validItems.Count <= 0)
-            return;
+        }
 
         // Select a random item index to apply.
         var chosenIdx = new Random().Next(0, validItems.Count);

--- a/ProjectGagSpeak/State/Managers/CacheManagers/CacheStateManager.cs
+++ b/ProjectGagSpeak/State/Managers/CacheManagers/CacheStateManager.cs
@@ -294,12 +294,10 @@ public class CacheStateManager : IHostedService
 
     /// <summary> Adds a GagItem's visual properties to the cache at the defined layer. </summary>
     /// <remarks> Changes are immediately reflected and updated to the player. </remarks>
-    public async Task AddGagItem(GarblerRestriction item, int layerIdx, string enabler)
+    public async Task AddGagItem(GarblerRestriction item, int layerIdx, string enabler, bool applyTraits = true)
     {
         _logger.LogDebug($"Adding ({item.GagType.GagName()}) at layer {layerIdx}, enabled by ({enabler}).");
         var key = new CombinedCacheKey(ManagerPriority.Gags, layerIdx, enabler, item.GagType.GagName());
-        
-        var applyTraits = enabler != "Mimic" || _config.Current.CursedItemsApplyTraits;
         
         var tasks = new List<Task>
         {

--- a/ProjectGagSpeak/State/Managers/CacheManagers/CacheStateManager.cs
+++ b/ProjectGagSpeak/State/Managers/CacheManagers/CacheStateManager.cs
@@ -298,13 +298,17 @@ public class CacheStateManager : IHostedService
     {
         _logger.LogDebug($"Adding ({item.GagType.GagName()}) at layer {layerIdx}, enabled by ({enabler}).");
         var key = new CombinedCacheKey(ManagerPriority.Gags, layerIdx, enabler, item.GagType.GagName());
-
+        
+        var applyTraits = enabler != "Mimic" || _config.Current.CursedItemsApplyTraits;
+        
         var tasks = new List<Task>
         {
             AddLociItem(key, item.LociData),
-            AddTraits(key, item.Traits),
             AddArousalStrength(key, item.Arousal)
         };
+        
+        if (applyTraits)
+            tasks.Add(AddTraits(key, item.Traits));
 
         if (item.IsEnabled)
         {

--- a/ProjectGagSpeak/State/Managers/CacheManagers/CacheStateManager.cs
+++ b/ProjectGagSpeak/State/Managers/CacheManagers/CacheStateManager.cs
@@ -124,9 +124,28 @@ public class CacheStateManager : IHostedService
         bool anyRequestedRedraw = false;
         _gags.LoadServerData(connectionDto.GagData);
         _logger.LogInformation("------ Syncing Gag Data to Cache ------");
+        // Gag slots enabled by "Mimic" are cursed loot gags, and are cached through the cursed loot system instead.
+        var cursedGagSlots = new Dictionary<int, CursedGagItem>();
         foreach (var (layer, gagItem) in _gags.ActiveItems)
         {
             var serverItem = _gags.ServerGagData!.GagSlots[layer];
+            if (serverItem.Enabler == "Mimic")
+            {
+                // Locate the cursed loot item this gag slot belongs to, favoring ones already marked as applied.
+                var lootItem = _cursedItems.Storage.OfType<CursedGagItem>()
+                    .Where(c => c.RefItem?.GagType == gagItem.GagType && !cursedGagSlots.ContainsValue(c))
+                    .OrderByDescending(c => c.IsActive())
+                    .FirstOrDefault();
+                if (lootItem is not null)
+                {
+                    // if the loot lost its applied state (config desync), restore it from the slot's mimic timer.
+                    if (!lootItem.IsActive())
+                        _cursedItems.ActivateItem(lootItem, serverItem.Timer);
+                    cursedGagSlots[layer] = lootItem;
+                    continue;
+                }
+                _logger.LogWarning($"No CursedGagItem found for Mimic-applied gag ({gagItem.GagType.GagName()}), treating as a normal gag.");
+            }
             _logger.LogDebug($"Adding ({gagItem.GagType.GagName()}) at layer {layer}, which was enabled by {serverItem.Enabler}.");
 
             var key = new CombinedCacheKey(ManagerPriority.Gags, layer, serverItem.Enabler, gagItem.GagType.GagName());
@@ -137,11 +156,17 @@ public class CacheStateManager : IHostedService
                 _modHandler.TryAddModToCache(key, gagItem.Mod);
             }
             _lociHandler.TryAddLociItemToCache(key, gagItem.LociData);
-            _traitsHandler.TryAddTraitsToCache(key, gagItem.Traits);
+            _traitsHandler.TryAddTraitsToCache(key, GagTraitsForEnabler(gagItem, serverItem.Enabler));
             _cplusHandler.TryAddToCache(key, gagItem.CPlusProfile);
             _arousalHandler.TryAddArousalToCache(key, gagItem.Arousal);
 
             anyRequestedRedraw |= gagItem.DoRedraw;
+        }
+        // Deactivate any applied cursed gags that no longer hold a gag slot on the server. (expired while we were away)
+        foreach (var staleGag in _cursedItems.Storage.AppliedLootUnsorted.OfType<CursedGagItem>().Where(c => !cursedGagSlots.ContainsValue(c)).ToArray())
+        {
+            _logger.LogDebug($"Cursed Gag [{staleGag.Label}] was applied locally but holds no gag slot on the server, deactivating.");
+            _cursedItems.SetInactive(staleGag.Identifier);
         }
         _logger.LogInformation("------ Gag Data synced to Cache ------ ");
 
@@ -245,6 +270,26 @@ public class CacheStateManager : IHostedService
             anyRequestedRedraw |= item.DoRedraw;
         }
 
+        // Sync the cursed loot gags found during the gag data sync. (these use the gag slot layer, which never collides with cursed restriction keys)
+        foreach (var (layer, loot) in cursedGagSlots)
+        {
+            var refGag = loot.RefItem;
+            _logger.LogDebug($"Adding Cursed Gag [{loot.Label}] at gag layer {layer}.");
+            var key = new CombinedCacheKey(ManagerPriority.CursedLoot, layer, "Mimic", $"Cursed {loot.Label}");
+            if (refGag.IsEnabled)
+            {
+                _glamourHandler.TryAddGlamourToCache(key, refGag.Glamour);
+                _glamourHandler.TryAddMetaToCache(key, new(refGag.HeadgearState, refGag.VisorState));
+                _modHandler.TryAddModToCache(key, refGag.Mod);
+            }
+            _lociHandler.TryAddLociItemToCache(key, refGag.LociData);
+            _cplusHandler.TryAddToCache(key, refGag.CPlusProfile);
+            if (_config.Current.CursedItemsApplyTraits && loot.ApplyTraits)
+                _traitsHandler.TryAddTraitsToCache(key, refGag.Traits & ~(Traits.Immobile | Traits.Weighty));
+            _arousalHandler.TryAddArousalToCache(key, refGag.Arousal);
+
+            anyRequestedRedraw |= refGag.DoRedraw;
+        }
 
         _logger.LogInformation("------ Cursed Item Data synced to Cache ------ ");
 
@@ -302,7 +347,7 @@ public class CacheStateManager : IHostedService
         var tasks = new List<Task>
         {
             AddLociItem(key, item.LociData),
-            AddTraits(key, item.Traits),
+            AddTraits(key, GagTraitsForEnabler(item, enabler)),
             AddArousalStrength(key, item.Arousal)
         };
 
@@ -606,6 +651,52 @@ public class CacheStateManager : IHostedService
             _redrawAssist.RedrawObject();
     }
 
+    /// <summary> Adds a cursed loot gag's visual properties to the cache, keyed by the gag slot layer it occupies. </summary>
+    /// <remarks> The gag slot layers (0-2) never collide with the generated cursed restriction keys (1000+). </remarks>
+    public async Task AddCursedGagItem(CursedGagItem item, int layer)
+    {
+        _logger.LogDebug($"Adding Cursed Gag [{item.Label}] with ({item.Precedence}) precedence to gag layer {layer}.");
+        var refGag = item.RefItem;
+        var key = new CombinedCacheKey(ManagerPriority.CursedLoot, layer, "Mimic", $"Cursed {item.Label}");
+        var tasks = new List<Task>
+        {
+            AddLociItem(key, refGag.LociData),
+            AddArousalStrength(key, refGag.Arousal)
+        };
+        if (refGag.IsEnabled)
+        {
+            tasks.Add(AddGlamourMeta(key, refGag.Glamour, new(refGag.HeadgearState, refGag.VisorState)));
+            tasks.Add(AddModPreset(key, refGag.Mod));
+            tasks.Add(AddProfile(key, refGag.CPlusProfile));
+        }
+        if (_config.Current.CursedItemsApplyTraits && item.ApplyTraits)
+            tasks.Add(AddTraits(key, refGag.Traits & ~(Traits.Immobile | Traits.Weighty)));
+
+        // Run in parallel.
+        await TimedWhenAll($"[{key}]'s Visual Attributes added to caches", tasks);
+        // Handle Redraw afterwards
+        if (refGag.DoRedraw)
+            _redrawAssist.RedrawObject();
+    }
+
+    public async Task RemoveCursedGagItem(CursedGagItem item, int layer)
+    {
+        _logger.LogInformation($"Removing Cursed Gag [{item.Label}] from gag layer {layer}");
+        var key = new CombinedCacheKey(ManagerPriority.CursedLoot, layer, "Mimic", string.Empty);
+        // Remove and update in parallel.
+        await TimedWhenAll($"[{key}] removed from cache and base states restored",
+            RemoveGlamourMeta(key),
+            RemoveModPreset(key),
+            RemoveLociData(key),
+            RemoveProfile(key),
+            RemoveTraits(key),
+            RemoveArousalStrength(key)
+        );
+        // Handle Redraw afterwards
+        if (item.RefItem.DoRedraw)
+            _redrawAssist.RedrawObject();
+    }
+
     // Always use MainHub.UID for the applier so that we can track the updates easier.
     // Assumed SyncedData is valid.
     public async Task AddCollar(UserData enactor)
@@ -655,6 +746,11 @@ public class CacheStateManager : IHostedService
             RemoveLociData(key)
         );
     }
+
+    /// <summary> Gates a gag's traits when applied by a Mimic, so cursed loot gags never apply traits unrestricted. </summary>
+    private Traits GagTraitsForEnabler(GarblerRestriction gag, string enabler)
+        => enabler != "Mimic" ? gag.Traits
+            : _config.Current.CursedItemsApplyTraits ? gag.Traits & ~(Traits.Immobile | Traits.Weighty) : Traits.None;
 
     private async Task TimedWhenAll(string label, IEnumerable<Task> tasks)
     {

--- a/ProjectGagSpeak/State/Managers/CacheManagers/CacheStateManager.cs
+++ b/ProjectGagSpeak/State/Managers/CacheManagers/CacheStateManager.cs
@@ -298,17 +298,13 @@ public class CacheStateManager : IHostedService
     {
         _logger.LogDebug($"Adding ({item.GagType.GagName()}) at layer {layerIdx}, enabled by ({enabler}).");
         var key = new CombinedCacheKey(ManagerPriority.Gags, layerIdx, enabler, item.GagType.GagName());
-        
-        var applyTraits = enabler != "Mimic" || _config.Current.CursedItemsApplyTraits;
-        
+
         var tasks = new List<Task>
         {
             AddLociItem(key, item.LociData),
+            AddTraits(key, item.Traits),
             AddArousalStrength(key, item.Arousal)
         };
-        
-        if (applyTraits)
-            tasks.Add(AddTraits(key, item.Traits));
 
         if (item.IsEnabled)
         {

--- a/ProjectGagSpeak/State/Managers/CacheManagers/CacheStateManager.cs
+++ b/ProjectGagSpeak/State/Managers/CacheManagers/CacheStateManager.cs
@@ -294,10 +294,12 @@ public class CacheStateManager : IHostedService
 
     /// <summary> Adds a GagItem's visual properties to the cache at the defined layer. </summary>
     /// <remarks> Changes are immediately reflected and updated to the player. </remarks>
-    public async Task AddGagItem(GarblerRestriction item, int layerIdx, string enabler, bool applyTraits = true)
+    public async Task AddGagItem(GarblerRestriction item, int layerIdx, string enabler)
     {
         _logger.LogDebug($"Adding ({item.GagType.GagName()}) at layer {layerIdx}, enabled by ({enabler}).");
         var key = new CombinedCacheKey(ManagerPriority.Gags, layerIdx, enabler, item.GagType.GagName());
+        
+        var applyTraits = enabler != "Mimic" || _config.Current.CursedItemsApplyTraits;
         
         var tasks = new List<Task>
         {

--- a/ProjectGagSpeak/State/Managers/CacheManagers/CursedLootManager.cs
+++ b/ProjectGagSpeak/State/Managers/CacheManagers/CursedLootManager.cs
@@ -146,6 +146,7 @@ public sealed class CursedLootManager : IHybridSavable
             item.AppliedTime = DateTimeOffset.MinValue;
             item.ReleaseTime = DateTimeOffset.MinValue;
         }
+        RefundUnservedTime();
         _saver.Save(this);
         SyncGarblerWithCursedGags();
     }
@@ -160,12 +161,46 @@ public sealed class CursedLootManager : IHybridSavable
     }
 
     // does not relate to the cached item, handle this seperately in the visual listener.
-    public void ActivateItem(CursedItem item, DateTimeOffset endTimeUtc)
+    // newEncounter should only be true for freshly opened loot, not for re-activations from a server sync.
+    public void ActivateItem(CursedItem item, DateTimeOffset endTimeUtc, bool newEncounter = false)
     {
         item.AppliedTime = DateTimeOffset.UtcNow;
         item.ReleaseTime = endTimeUtc;
+        if (newEncounter)
+            RecordEncounterStats(item, endTimeUtc);
         _saver.Save(this);
         SyncGarblerWithCursedGags();
+    }
+
+    public void RecordMimicEvaded()
+    {
+        MimicsEvaded++;
+        _saver.Save(this);
+    }
+
+    private void RecordEncounterStats(CursedItem item, DateTimeOffset endTimeUtc)
+    {
+        TotalEncounters++;
+        if (item is CursedGagItem)
+            GagEncounters++;
+        else if (item is CursedRestrictionItem)
+            BindEncounters++;
+
+        var lockTime = endTimeUtc - item.AppliedTime;
+        if (lockTime > LongestLockTime)
+            LongestLockTime = lockTime;
+
+        // Only count time not already covered by other active loot, so overlapping locks don't inflate the total.
+        if (endTimeUtc > CursedTimeCoveredUntil)
+        {
+            var countFrom = item.AppliedTime > CursedTimeCoveredUntil ? item.AppliedTime : CursedTimeCoveredUntil;
+            TimeInCursedLoot += endTimeUtc - countFrom;
+            CursedTimeCoveredUntil = endTimeUtc;
+        }
+
+        var activeCount = Storage.AppliedLootIds.Count();
+        if (activeCount > MaxLootActiveAtOnce)
+            MaxLootActiveAtOnce = activeCount;
     }
 
     public void SetInactive(Guid lootId)
@@ -174,8 +209,28 @@ public sealed class CursedLootManager : IHybridSavable
             return;
         item.AppliedTime = DateTimeOffset.MinValue;
         item.ReleaseTime = DateTimeOffset.MinValue;
+        RefundUnservedTime();
         _saver.Save(this);
         SyncGarblerWithCursedGags();
+    }
+
+    /// <summary> Removes any counted lock time that will no longer be served after an early release. </summary>
+    /// <remarks> Remaining active items all began in the past, so their future coverage is the contiguous span [now, max release]. </remarks>
+    private void RefundUnservedTime()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var stillCovered = Storage.AppliedLootUnsorted
+            .Select(i => i.ReleaseTime)
+            .DefaultIfEmpty(now)
+            .Max();
+        if (stillCovered < now)
+            stillCovered = now;
+
+        if (CursedTimeCoveredUntil > stillCovered)
+        {
+            TimeInCursedLoot -= CursedTimeCoveredUntil - stillCovered;
+            CursedTimeCoveredUntil = stillCovered;
+        }
     }
 
     public void SetLowerLimit(TimeSpan time)
@@ -208,6 +263,8 @@ public sealed class CursedLootManager : IHybridSavable
     public TimeSpan TimeInCursedLoot { get; set; } = TimeSpan.Zero;
     public TimeSpan LongestLockTime { get; set; } = TimeSpan.Zero;
     public int MaxLootActiveAtOnce { get; set; } = 0;
+    // Tracks how far into the future TimeInCursedLoot has already been counted, so overlapping locks are not double counted.
+    public DateTimeOffset CursedTimeCoveredUntil { get; set; } = DateTimeOffset.MinValue;
 
 
     public int ConfigVersion => 0;
@@ -237,6 +294,7 @@ public sealed class CursedLootManager : IHybridSavable
             ["TimeInCursedLoot"] = TimeInCursedLoot.ToString(),
             ["LongestLockTime"] = LongestLockTime.ToString(),
             ["MaxLootActiveAtOnce"] = MaxLootActiveAtOnce,
+            ["CursedTimeCoveredUntil"] = CursedTimeCoveredUntil.UtcDateTime.ToString("o"),
             ["CursedItems"] = cursedItems,
         }.ToString(Formatting.Indented);
     }
@@ -310,6 +368,7 @@ public sealed class CursedLootManager : IHybridSavable
         TimeInCursedLoot = TimeSpan.TryParse(cursedLootData["TimeInCursedLoot"]?.Value<string>(), out var timeInLoot) ? timeInLoot : TimeSpan.Zero;
         LongestLockTime = TimeSpan.TryParse(cursedLootData["LongestLockTime"]?.Value<string>(), out var longestLock) ? longestLock : TimeSpan.Zero;
         MaxLootActiveAtOnce = cursedLootData["MaxLootActiveAtOnce"]?.Value<int>() ?? 0;
+        CursedTimeCoveredUntil = DateTimeOffset.TryParse(cursedLootData["CursedTimeCoveredUntil"]?.Value<string>(), out var coveredUntil) ? coveredUntil : DateTimeOffset.MinValue;
 
         // get the array of cursed loot items from the token
         if (cursedLootData["CursedItems"] is not JArray lootItemsList)

--- a/ProjectGagSpeak/State/Managers/CacheManagers/CursedLootManager.cs
+++ b/ProjectGagSpeak/State/Managers/CacheManagers/CursedLootManager.cs
@@ -141,12 +141,19 @@ public sealed class CursedLootManager : IHybridSavable
     // Called from safeword service, deactivates all items.
     public void InvalidateAllActive()
     {
-        foreach (var item in Storage.ActiveAppliedLoot.ToArray())
+        foreach (var item in Storage.AppliedLootUnsorted.ToArray())
         {
             item.AppliedTime = DateTimeOffset.MinValue;
             item.ReleaseTime = DateTimeOffset.MinValue;
+            item.CreditedUntil = DateTimeOffset.MinValue;
         }
-        RefundUnservedTime();
+        // Nothing remains active, so anything credited beyond "now" will never be served - claw it all back.
+        var now = DateTimeOffset.UtcNow;
+        if (CursedTimeCoveredUntil > now)
+        {
+            TimeInCursedLoot -= CursedTimeCoveredUntil - now;
+            CursedTimeCoveredUntil = now;
+        }
         _saver.Save(this);
         SyncGarblerWithCursedGags();
     }
@@ -196,6 +203,7 @@ public sealed class CursedLootManager : IHybridSavable
             var countFrom = item.AppliedTime > CursedTimeCoveredUntil ? item.AppliedTime : CursedTimeCoveredUntil;
             TimeInCursedLoot += endTimeUtc - countFrom;
             CursedTimeCoveredUntil = endTimeUtc;
+            item.CreditedUntil = endTimeUtc;
         }
 
         var activeCount = Storage.AppliedLootIds.Count();
@@ -207,24 +215,31 @@ public sealed class CursedLootManager : IHybridSavable
     {
         if (!Storage.TryGetLoot(lootId, out var item))
             return;
+        RefundUnservedTime(item);
         item.AppliedTime = DateTimeOffset.MinValue;
         item.ReleaseTime = DateTimeOffset.MinValue;
-        RefundUnservedTime();
+        item.CreditedUntil = DateTimeOffset.MinValue;
         _saver.Save(this);
         SyncGarblerWithCursedGags();
     }
 
     /// <summary> Removes any counted lock time that will no longer be served after an early release. </summary>
-    /// <remarks> Remaining active items all began in the past, so their future coverage is the contiguous span [now, max release]. </remarks>
-    private void RefundUnservedTime()
+    /// <remarks>
+    /// Only refunds if <paramref name="item"/> is the one that currently owns the watermark it advanced
+    /// (via <see cref="RecordEncounterStats"/>).
+    /// Remaining active items all began in the past, so their future coverage is the contiguous span [now, max release].
+    /// </remarks>
+    private void RefundUnservedTime(CursedItem item)
     {
+        if (item.CreditedUntil == DateTimeOffset.MinValue || item.CreditedUntil != CursedTimeCoveredUntil)
+            return;
+
         var now = DateTimeOffset.UtcNow;
         var stillCovered = Storage.AppliedLootUnsorted
+            .Where(i => i.Identifier != item.Identifier)
             .Select(i => i.ReleaseTime)
-            .DefaultIfEmpty(now)
+            .Append(now)
             .Max();
-        if (stillCovered < now)
-            stillCovered = now;
 
         if (CursedTimeCoveredUntil > stillCovered)
         {
@@ -260,7 +275,20 @@ public sealed class CursedLootManager : IHybridSavable
     public int GagEncounters { get; set; } = 0;
     public int BindEncounters { get; set; } = 0;
     public int MimicsEvaded { get; set; } = 0;
-    public TimeSpan TimeInCursedLoot { get; set; } = TimeSpan.Zero;
+    private TimeSpan _timeInCursedLoot = TimeSpan.Zero;
+    public TimeSpan TimeInCursedLoot
+    {
+        get => _timeInCursedLoot;
+        set
+        {
+            if (value < TimeSpan.Zero)
+            {
+                _logger.LogWarning($"TimeInCursedLoot was set to a negative value ({value}), clamping to zero.");
+                value = TimeSpan.Zero;
+            }
+            _timeInCursedLoot = value;
+        }
+    }
     public TimeSpan LongestLockTime { get; set; } = TimeSpan.Zero;
     public int MaxLootActiveAtOnce { get; set; } = 0;
     // Tracks how far into the future TimeInCursedLoot has already been counted, so overlapping locks are not double counted.
@@ -368,7 +396,7 @@ public sealed class CursedLootManager : IHybridSavable
         TimeInCursedLoot = TimeSpan.TryParse(cursedLootData["TimeInCursedLoot"]?.Value<string>(), out var timeInLoot) ? timeInLoot : TimeSpan.Zero;
         LongestLockTime = TimeSpan.TryParse(cursedLootData["LongestLockTime"]?.Value<string>(), out var longestLock) ? longestLock : TimeSpan.Zero;
         MaxLootActiveAtOnce = cursedLootData["MaxLootActiveAtOnce"]?.Value<int>() ?? 0;
-        CursedTimeCoveredUntil = DateTimeOffset.TryParse(cursedLootData["CursedTimeCoveredUntil"]?.Value<string>(), out var coveredUntil) ? coveredUntil : DateTimeOffset.MinValue;
+        CursedTimeCoveredUntil = ReadUtcTime(cursedLootData["CursedTimeCoveredUntil"]);
 
         // get the array of cursed loot items from the token
         if (cursedLootData["CursedItems"] is not JArray lootItemsList)
@@ -400,6 +428,21 @@ public sealed class CursedLootManager : IHybridSavable
         }
     }
 
+    /// <summary> Reads a stored timestamp back as a UTC instant, regardless of how Newtonsoft typed the token. </summary>
+    private static DateTimeOffset ReadUtcTime(JToken? token)
+    {
+        if (token is null || token.Type is JTokenType.Null)
+            return DateTimeOffset.MinValue;
+
+        var time = token.Value<DateTime>();
+        return time.Kind switch
+        {
+            DateTimeKind.Utc => new DateTimeOffset(time, TimeSpan.Zero),
+            DateTimeKind.Local => new DateTimeOffset(time).ToUniversalTime(),
+            _ => new DateTimeOffset(DateTime.SpecifyKind(time, DateTimeKind.Utc), TimeSpan.Zero),
+        };
+    }
+
     private void MigrateV0toV1(JObject oldConfigJson)
     {
         // update only the version value to 1, then return it.
@@ -414,8 +457,9 @@ public sealed class CursedLootManager : IHybridSavable
 
         try
         {
-            var applyTime = token["AppliedTime"]?.Value<DateTime>() ?? DateTime.MinValue;
-            var releaseTime = token["ReleaseTime"]?.Value<DateTime>() ?? DateTime.MinValue;
+            var applyTime = ReadUtcTime(token["AppliedTime"]);
+            var releaseTime = ReadUtcTime(token["ReleaseTime"]);
+            var creditedUntil = ReadUtcTime(token["CreditedUntil"]);
             // get the gag by the gagtype.
             if (token["GagRef"] is not JValue gagRefValue)
                 return null;
@@ -430,8 +474,9 @@ public sealed class CursedLootManager : IHybridSavable
                 Identifier = token["Identifier"]?.ToObject<Guid>() ?? throw new ArgumentNullException("Identifier"),
                 Label = token["Label"]?.Value<string>() ?? string.Empty,
                 InPool = token["InPool"]?.Value<bool>() ?? false,
-                AppliedTime = new DateTimeOffset(applyTime, TimeSpan.Zero),
-                ReleaseTime = new DateTimeOffset(releaseTime, TimeSpan.Zero),
+                AppliedTime = applyTime,
+                ReleaseTime = releaseTime,
+                CreditedUntil = creditedUntil,
                 Precedence = Enum.TryParse<Precedence>(token["Precedence"]?.Value<string>(), out var precedence) ? precedence : Precedence.Default,
                 ApplyTraits = token["ApplyTraits"]?.Value<bool>() ?? true,
                 RefItem = gagRef
@@ -451,8 +496,9 @@ public sealed class CursedLootManager : IHybridSavable
             return null;
         try
         {
-            var applyTime = token["AppliedTime"]?.Value<DateTime>() ?? DateTime.MinValue;
-            var releaseTime = token["ReleaseTime"]?.Value<DateTime>() ?? DateTime.MinValue;
+            var applyTime = ReadUtcTime(token["AppliedTime"]);
+            var releaseTime = ReadUtcTime(token["ReleaseTime"]);
+            var creditedUntil = ReadUtcTime(token["CreditedUntil"]);
             // get the restriction by the GUID.
             if (token["RestrictionRef"] is not JValue restRefValue)
                 return null;
@@ -467,8 +513,9 @@ public sealed class CursedLootManager : IHybridSavable
                 Identifier = token["Identifier"]?.ToObject<Guid>() ?? throw new ArgumentNullException("Identifier"),
                 Label = token["Label"]?.Value<string>() ?? string.Empty,
                 InPool = token["InPool"]?.Value<bool>() ?? false,
-                AppliedTime = new DateTimeOffset(applyTime, TimeSpan.Zero),
-                ReleaseTime = new DateTimeOffset(releaseTime, TimeSpan.Zero),
+                AppliedTime = applyTime,
+                ReleaseTime = releaseTime,
+                CreditedUntil = creditedUntil,
                 Precedence = Enum.TryParse<Precedence>(token["Precedence"]?.Value<string>(), out var precedence) ? precedence : Precedence.Default,
                 ApplyTraits = token["ApplyTraits"]?.Value<bool>() ?? true,
                 RefItem = restRef

--- a/ProjectGagSpeak/State/Managers/CacheManagers/CursedLootManager.cs
+++ b/ProjectGagSpeak/State/Managers/CacheManagers/CursedLootManager.cs
@@ -133,6 +133,11 @@ public sealed class CursedLootManager : IHybridSavable
     public void AddFavorite(CursedItem loot) => _favorites.TryAddRestriction(FavoriteIdContainer.CursedLoot, loot.Identifier);
     public void RemoveFavorite(CursedItem loot) => _favorites.RemoveRestriction(FavoriteIdContainer.CursedLoot, loot.Identifier);
     #endregion Generic Methods
+    /// <summary> Feeds the chat garbler the gag types of all applied cursed loot gags. </summary>
+    /// <remarks> Required, as cursed loot gags garble through this list instead of the gag slots. </remarks>
+    private void SyncGarblerWithCursedGags()
+        => _gags.SetCursedLootGags(Storage.AppliedLootUnsorted.OfType<CursedGagItem>().Where(c => c.RefItem is not null).Select(c => c.RefItem.GagType));
+
     // Called from safeword service, deactivates all items.
     public void InvalidateAllActive()
     {
@@ -142,6 +147,7 @@ public sealed class CursedLootManager : IHybridSavable
             item.ReleaseTime = DateTimeOffset.MinValue;
         }
         _saver.Save(this);
+        SyncGarblerWithCursedGags();
     }
 
     public void ForceSave() => _saver.Save(this);
@@ -159,6 +165,7 @@ public sealed class CursedLootManager : IHybridSavable
         item.AppliedTime = DateTimeOffset.UtcNow;
         item.ReleaseTime = endTimeUtc;
         _saver.Save(this);
+        SyncGarblerWithCursedGags();
     }
 
     public void SetInactive(Guid lootId)
@@ -168,6 +175,7 @@ public sealed class CursedLootManager : IHybridSavable
         item.AppliedTime = DateTimeOffset.MinValue;
         item.ReleaseTime = DateTimeOffset.MinValue;
         _saver.Save(this);
+        SyncGarblerWithCursedGags();
     }
 
     public void SetLowerLimit(TimeSpan time)
@@ -281,6 +289,8 @@ public sealed class CursedLootManager : IHybridSavable
         }
         // run a save after the load.
         _saver.Save(this);
+        // feed the garbler any cursed gags that were applied when this config last saved. Might not need?
+        SyncGarblerWithCursedGags();
         _mediator.Publish(new ReloadFileSystem(GSModule.CursedLoot));
     }
 

--- a/ProjectGagSpeak/State/Managers/GagRestrictionsManager.cs
+++ b/ProjectGagSpeak/State/Managers/GagRestrictionsManager.cs
@@ -27,6 +27,7 @@ public sealed class GagRestrictionManager : IHybridSavable
     private StorageItemEditor<GarblerRestriction> _itemEditor = new();
     private CharaActiveGags? _serverGagData = null;
     private Dictionary<int, GarblerRestriction> _activeItems = new();
+    private IReadOnlyList<GagType> _cursedLootGags = [];
 
     public GagRestrictionManager(
         ILogger<GagRestrictionManager> logger,
@@ -65,8 +66,25 @@ public sealed class GagRestrictionManager : IHybridSavable
             if (slot.GagItem is not GagType.None && Storage.TryGetGag(slot.GagItem, out var item))
                 _activeItems.TryAdd(idx, item);
         // resync the active chat garbler data if any were set.
-        _muffler.UpdateGarblerLogic(serverData.CurrentGagNames(), MufflerService.MuffleType(serverData.GagSlots.Select(g => g.GagItem)));
+        RefreshGarblerLogic();
         _logger.LogInformation("Synchronized all Active GagSlots with Client-Side Manager.");
+    }
+
+    /// <summary> Updates the cursed loot gags fed to the chat garbler. </summary>
+    /// <remarks> Cursed loot gags garble through this list, and not the gag slots, as eventually they will no longer occupy one. </remarks>
+    public void SetCursedLootGags(IEnumerable<GagType> gags)
+    {
+        _cursedLootGags = gags.ToList();
+        RefreshGarblerLogic();
+    }
+
+    /// <summary> Rebuilds the chat garbler from the active gag slots and the applied cursed loot gags. </summary>
+    /// <remarks> Mimic-enabled slots are excluded; while cursed gags still occupy a server slot, they only garble via the cursed loot list. Will remove when the server no longer occupies a slot for cursed loot. </remarks>
+    private void RefreshGarblerLogic()
+    {
+        var slotGags = _serverGagData?.GagSlots.Where(s => s.Enabler != "Mimic").Select(s => s.GagItem) ?? [];
+        var allGags = slotGags.Concat(_cursedLootGags).Where(g => g is not GagType.None).Distinct().ToList();
+        _muffler.UpdateGarblerLogic(allGags.Select(g => g.GagName()).ToList(), MufflerService.MuffleType(allGags));
     }
 
     /// <summary> Begin the editing process, making a clone of the item we want to edit. </summary>
@@ -137,7 +155,7 @@ public sealed class GagRestrictionManager : IHybridSavable
 
         _logger.LogTrace($"Updating Garbler Logic for gag {newGag.GagName()} to layer {layer} by {enactor}");
         // Update the garbler logic to reflect the new gags.
-        _muffler.UpdateGarblerLogic(data.CurrentGagNames(), MufflerService.MuffleType(data.GagSlots.Select(g => g.GagItem)));
+        RefreshGarblerLogic();
         // Invoke the Mediator of this change.
         _mediator.Publish(new GagStateChanged(NewState.Enabled, layer, data.GagSlots[layer], enactor, MainHub.UID));
 
@@ -196,7 +214,7 @@ public sealed class GagRestrictionManager : IHybridSavable
         data.GagSlots[layer].GagItem = GagType.None;
         data.GagSlots[layer].Enabler = string.Empty;
         // Update the garbler logic to reflect the new gags.
-        _muffler.UpdateGarblerLogic(data.CurrentGagNames(), MufflerService.MuffleType(data.GagSlots.Select(g => g.GagItem)));
+        RefreshGarblerLogic();
         _mediator.Publish(new GagStateChanged(NewState.Disabled, layer, prev, enactor, MainHub.UID));
 
         // Update the affected visual states, if item is enabled.

--- a/ProjectGagSpeak/State/_Models/CursedItem.cs
+++ b/ProjectGagSpeak/State/_Models/CursedItem.cs
@@ -14,6 +14,7 @@ public abstract class CursedItem : IEditableStorageItem<CursedItem>
     public string Label { get; set; } = string.Empty;
     public DateTimeOffset AppliedTime { get; set; } = DateTimeOffset.MinValue;
     public DateTimeOffset ReleaseTime { get; set; } = DateTimeOffset.MinValue;
+    public DateTimeOffset CreditedUntil { get; set; } = DateTimeOffset.MinValue;
     public Precedence Precedence { get; set; } = Precedence.Default; // the priority system.
     public bool ApplyTraits { get; set; } = true; // For Hardcore Traits.
 
@@ -36,6 +37,7 @@ public abstract class CursedItem : IEditableStorageItem<CursedItem>
         InPool = other.InPool;
         AppliedTime = other.AppliedTime;
         ReleaseTime = other.ReleaseTime;
+        CreditedUntil = other.CreditedUntil;
         Precedence = other.Precedence;
         ApplyTraits = other.ApplyTraits;
     }
@@ -116,6 +118,7 @@ public class CursedGagItem : CursedItem
             ["Label"] = Label,
             ["AppliedTime"] = AppliedTime.UtcDateTime.ToString("o"),
             ["ReleaseTime"] = ReleaseTime.UtcDateTime.ToString("o"),
+            ["CreditedUntil"] = CreditedUntil.UtcDateTime.ToString("o"),
             ["Precedence"] = Precedence.ToString(),
             ["GagRef"] = RefItem.GagType.ToString(),
             ["ApplyTraits"] = ApplyTraits
@@ -168,6 +171,7 @@ public class CursedRestrictionItem : CursedItem
             ["Label"] = Label,
             ["AppliedTime"] = AppliedTime.UtcDateTime.ToString("o"),
             ["ReleaseTime"] = ReleaseTime.UtcDateTime.ToString("o"),
+            ["CreditedUntil"] = CreditedUntil.UtcDateTime.ToString("o"),
             ["Precedence"] = Precedence.ToString(),
             ["RestrictionRef"] = RefItem.Identifier.ToString(),
             ["ApplyTraits"] = ApplyTraits


### PR DESCRIPTION
added implementation for tracking cursed loot stats

Records encounters, gag/bind splits, mimics evaded, longest lock, and max simultaneous loot on each fresh mimic application.

TimeInCursedLoot counts the union of lock intervals via a persisted CursedTimeCoveredUntil variable, so overlapping locks don't inflate the total. Early release (safeword, manual removal) refunds any counted time remaining lock still cover.

Mimic evasion is counted on failed lock rolls, and the roll only happens when unapplied loot exists in the loot pool so evasion stats aren't skewed.

the change is located in https://github.com/Project-GagSpeak/client/pull/177/commits/94bf8cae191dcb10badbe828919343885eaa4068

requires #140 
includes #140 
closes #140 