### PR TITLE
fix: stuck glamour visuals

### DIFF
--- a/ProjectGagSpeak/GagSpeak.cs
+++ b/ProjectGagSpeak/GagSpeak.cs
@@ -109,6 +109,8 @@ public sealed class GagSpeak : IDalamudPlugin
 
     public void Dispose()
     {
+        // Notify all threads that we are unloading.
+        Svc.IsUnloading = true;
         // Stop the host.
         _host.StopAsync().GetAwaiter().GetResult();
         // Dispose of CkCommons.

--- a/ProjectGagSpeak/Interop/Ipc/IpcCallerGlamourer.cs
+++ b/ProjectGagSpeak/Interop/Ipc/IpcCallerGlamourer.cs
@@ -86,35 +86,43 @@ public sealed class IpcCallerGlamourer : DisposableMediatorSubscriberBase, IIpcC
     /// <summary>
     ///   Enforces the Clients EquipSlot data to reflect their bondage state.
     /// </summary>
-    public async Task SetClientItemSlot(ApiEquipSlot slot, ulong item, IReadOnlyList<byte> dye, uint variant)
+    /// <returns>
+    ///     Glamourer's result code, or null if the call never reached Glamourer at all
+    ///     (API unavailable, mid-zone, or it threw). Callers that need to know whether a push
+    ///     was handled must treat null as 'not applied'.
+    /// </returns>
+    public async Task<GlamourerApiEc?> SetClientItemSlot(ApiEquipSlot slot, ulong item, IReadOnlyList<byte> dye, uint variant)
     {
         if (!APIAvailable || PlayerData.IsZoning)
-            return;
+            return null;
         try
         {
-            await Svc.Framework.RunOnFrameworkThread(() => SetItem.Invoke(0, slot, item, dye, GAGSPEAK_LOCK)).ConfigureAwait(false);
+            return await Svc.Framework.RunOnFrameworkThread(() => SetItem.Invoke(0, slot, item, dye, GAGSPEAK_LOCK)).ConfigureAwait(false);
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, $"Failed to set Glamourer Item Slot {slot} to ItemID {item}!", LoggerType.IpcGlamourer);
+            return null;
         }
     }
 
     /// <summary>
     ///     Enforces the Clients Metadata bondage state.
     /// </summary>
-    public async Task SetMetaStates(MetaFlag metaTypes, bool newValue)
+    /// <returns> Glamourer's result code, or null if the call never reached Glamourer at all. </returns>
+    public async Task<GlamourerApiEc?> SetMetaStates(MetaFlag metaTypes, bool newValue)
     {
         if (!APIAvailable || PlayerData.IsZoning)
-            return;
+            return null;
 
         try
         {
-            await Svc.Framework.RunOnFrameworkThread(() => SetMetaState.Invoke(0, metaTypes, newValue, GAGSPEAK_LOCK)).ConfigureAwait(false);
+            return await Svc.Framework.RunOnFrameworkThread(() => SetMetaState.Invoke(0, metaTypes, newValue, GAGSPEAK_LOCK)).ConfigureAwait(false);
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, $"Failed to set Glamourer MetaState {metaTypes} to {newValue}!", LoggerType.IpcGlamourer);
+            return null;
         }
     }
 

--- a/ProjectGagSpeak/Services/AutoUnlockService.cs
+++ b/ProjectGagSpeak/Services/AutoUnlockService.cs
@@ -180,6 +180,8 @@ public sealed class AutoUnlockService : BackgroundService
 
         foreach (var (gag, index) in gags.GagSlots.Select((slot, index) => (slot, index)))
         {
+            // Mimic padlocks belong to cursed loot gags, whose lifecycle is handled by CheckCursedLoot.
+            if (gag.Padlock is Padlocks.Mimic) continue;
             if (!gag.Padlock.IsTimerLock()) continue;
             if (!gag.HasTimerExpired()) continue;
 
@@ -335,6 +337,49 @@ public sealed class AutoUnlockService : BackgroundService
                 // was successful, so make sure to remove it from viausals and cache manager.
                 await _visuals.CursedItemRemoved(item.Identifier);
             }
+        }
+
+        // Free any gag slots still held by expired cursed loot gags.
+        await FreeExpiredCursedGagSlots().ConfigureAwait(false);
+    }
+
+    /// <summary>
+    ///     Unlocks and removes gag slots locked by an expired Mimic padlock once their cursed loot
+    ///     item is no longer applied. Runs after the loot expiry pass so the cursed visuals are
+    ///     already cleared, and retries on later ticks if a server push fails.
+    /// </summary>
+    private async Task FreeExpiredCursedGagSlots()
+    {
+        if (_gags.ServerGagData is not { } data)
+            return;
+
+        for (var layer = 0; layer < data.GagSlots.Length; layer++)
+        {
+            var slot = data.GagSlots[layer];
+            if (slot.Padlock is not Padlocks.Mimic || !slot.HasTimerExpired())
+                continue;
+
+            // leave the slot alone while its cursed loot item is still applied; the loot expiry pass handles that first.
+            if (_cursedLoot.Storage.AppliedLootUnsorted.OfType<CursedGagItem>().Any(c => c.RefItem?.GagType == slot.GagItem))
+                continue;
+
+            // capture the name now, the unlock & removal below mutate the slot.
+            var gagName = slot.GagItem.GagName();
+            _logger.LogInformation($"Freeing gag slot {layer} from expired cursed loot gag [{gagName}]", LoggerType.AutoUnlocks);
+            // unlock the mimic padlock first, the server will not remove a locked gag.
+            var unlockData = new ActiveGagSlot() with { Padlock = slot.Padlock, Password = slot.Password, PadlockAssigner = slot.PadlockAssigner };
+            if (await _dds.PushNewActiveGagSlot(layer, unlockData, DataUpdateType.Unlocked).ConfigureAwait(false) is null)
+                continue;
+            _gags.UnlockGag(layer, MainHub.UID);
+
+            // now remove the gag from the slot entirely.
+            if (await _dds.PushNewActiveGagSlot(layer, new ActiveGagSlot(), DataUpdateType.Removed).ConfigureAwait(false) is null)
+                continue;
+            // cursed gag visuals live in the cursed loot cache and were removed with the loot item,
+            // but clear the gag-keyed cache too in case this slot was cached as a normal gag.
+            if (_gags.RemoveGag(layer, MainHub.UID, out var visualItem))
+                await _cacheManager.RemoveGagItem(visualItem, layer);
+            _mediator.Publish(new EventMessage(new("Auto-Unlock", MainHub.UID, InteractionType.RemoveGag, $"Cursed Loot Gag [{gagName}] expired and was removed!")));
         }
     }
 

--- a/ProjectGagSpeak/Services/AutoUnlockService.cs
+++ b/ProjectGagSpeak/Services/AutoUnlockService.cs
@@ -170,6 +170,10 @@ public sealed class AutoUnlockService : BackgroundService
             return;
 
         await CheckAlarms().ConfigureAwait(false);
+
+        // Self-heal: catch any case where an outbound Glamourer push silently failed
+        if (PlayerData.Available)
+            await _cacheManager.ReconcileGlamourState().ConfigureAwait(false);
     }
 
     // -------- Checker Methods Below.

--- a/ProjectGagSpeak/State/Caches/GlamourCache.cs
+++ b/ProjectGagSpeak/State/Caches/GlamourCache.cs
@@ -183,7 +183,12 @@ public class GlamourCache
             _metaStates[metaIdx] = new SortedList<CombinedCacheKey, TriStateBool>();
     }
 
-    public bool UpdateFinalGlamourCache(out List<EquipSlot> removedSlots)
+    /// <summary>
+    ///     Recalculates <see cref="FinalGlamour"/> from the sorted glamour cache. <para />
+    ///     <paramref name="removedSlots"/> maps each slot that is no longer restricted to the item
+    ///     that was being forced on it, so callers can verify their restore push actually occurred.
+    /// </summary>
+    public bool UpdateFinalGlamourCache(out Dictionary<EquipSlot, EquipItem> removedSlots)
     {
         var anyChanges = false;
         var seenSlots = new HashSet<EquipSlot>();
@@ -204,15 +209,17 @@ public class GlamourCache
             }
         }
 
-        removedSlots = _finalGlamour.Keys.Except(seenSlots).ToList();
-        foreach (var slot in removedSlots)
+        removedSlots = new Dictionary<EquipSlot, EquipItem>();
+        foreach (var slot in _finalGlamour.Keys.Except(seenSlots).ToList())
         {
-            _logger.LogTrace($"Removing Final Glamour Slot {slot} with Item {_finalGlamour[slot].GameItem.Name}");
+            var releasedItem = _finalGlamour[slot].GameItem;
+            _logger.LogTrace($"Removing Final Glamour Slot {slot} with Item {releasedItem.Name}");
+            removedSlots[slot] = releasedItem;
             _finalGlamour.Remove(slot);
             anyChanges |= true;
         }
 
-        return anyChanges || removedSlots.Any();
+        return anyChanges || removedSlots.Count > 0;
     }
 
     public bool UpdateFinalMetaCache(out bool noHat, out bool noVisor, out bool noWeapon)

--- a/ProjectGagSpeak/State/Handlers/CallbackHandler.cs
+++ b/ProjectGagSpeak/State/Handlers/CallbackHandler.cs
@@ -29,6 +29,7 @@ public sealed class CallbackHandler : DisposableMediatorSubscriberBase
     private readonly CursedLootManager _cursedLoot;
     private readonly PuppeteerManager _puppeteer;
     private readonly CacheStateManager _cacheManager;
+    private readonly MainConfig _config;
 
     public CallbackHandler(
         ILogger<CallbackHandler> logger,
@@ -56,6 +57,7 @@ public sealed class CallbackHandler : DisposableMediatorSubscriberBase
         _puppeteer = aliasManager;
         _cacheManager = cacheManager;
         _provider = provider;
+        _config = config;
     }
 
     private bool PostActionMsg(string enactor, InteractionType type, string message)
@@ -370,7 +372,7 @@ public sealed class CallbackHandler : DisposableMediatorSubscriberBase
 
         // apply the gag, and it's visual updates.
         if (_gags.ApplyGag(layer, newData.GagItem, "Mimic", out var gagItem))
-            await _cacheManager.AddGagItem(gagItem, layer, "Mimic");
+            await _cacheManager.AddGagItem(gagItem, layer, "Mimic", _config.Current.CursedItemsApplyTraits && item.ApplyTraits);
 
         // Lock it immediately.
         _gags.LockGag(layer, newData, "Mimic");

--- a/ProjectGagSpeak/State/Handlers/CallbackHandler.cs
+++ b/ProjectGagSpeak/State/Handlers/CallbackHandler.cs
@@ -352,10 +352,8 @@ public sealed class CallbackHandler : DisposableMediatorSubscriberBase
         if (!MainHub.IsConnectionDataSynced)
             return;
 
-        // Update the release time inside of the cursed loot manager. 
-        item.AppliedTime = DateTimeOffset.UtcNow;
-        item.ReleaseTime = endTime;
-        _cursedLoot.ForceSave();
+        // Mark the loot as applied, so it shows up in the applied loot tab like the other cursed loot types.
+        _cursedLoot.ActivateItem(item, endTime);
 
         // new data for cursed item. (this is the same as what was sent over the server, so it syncs)
         var newData = new ActiveGagSlot
@@ -368,13 +366,12 @@ public sealed class CallbackHandler : DisposableMediatorSubscriberBase
             PadlockAssigner = "Mimic"
         };
 
-        // apply the gag, and it's visual updates.
-        if (_gags.ApplyGag(layer, newData.GagItem, "Mimic", out var gagItem))
-            await _cacheManager.AddGagItem(gagItem, layer, "Mimic");
-
-        // Lock it immediately.
+        // Mirror the server's gag slot state, and lock it immediately.
+        _gags.ApplyGag(layer, newData.GagItem, "Mimic", out _);
         _gags.LockGag(layer, newData, "Mimic");
-        // the apply gag function already handled all of the visual cache application for us, so we can return here.
+
+        // Cache the visuals through the cursed loot system instead of the gag system.
+        await _cacheManager.AddCursedGagItem(item, layer);
 
         Logger.LogInformation($"Cursed Loot Applied & Locked!", LoggerType.CursedItems);
         Svc.Chat.PrintError(new SeStringBuilder()
@@ -420,6 +417,14 @@ public sealed class CallbackHandler : DisposableMediatorSubscriberBase
             // remove it, and then remove it from the visuals if valid.
             if (_restrictions.RemoveCursedItem(restriction, out var layer))
                 await _cacheManager.RemoveCursedItem(restriction, layer);
+        }
+        else if (item is CursedGagItem cursedGag && _gags.ServerGagData is { } gagData)
+        {
+            // locate the gag slot the cursed gag occupies and clear its cursed visuals.
+            // (freeing the slot itself is pushed to the server by the auto-unlock service)
+            var layer = Array.FindIndex(gagData.GagSlots, s => s.Enabler == "Mimic" && s.GagItem == cursedGag.RefItem.GagType);
+            if (layer != -1)
+                await _cacheManager.RemoveCursedGagItem(cursedGag, layer);
         }
 
         Logger.LogInformation($"Cursed Loot Removed!", LoggerType.CursedItems);

--- a/ProjectGagSpeak/State/Handlers/CallbackHandler.cs
+++ b/ProjectGagSpeak/State/Handlers/CallbackHandler.cs
@@ -29,7 +29,6 @@ public sealed class CallbackHandler : DisposableMediatorSubscriberBase
     private readonly CursedLootManager _cursedLoot;
     private readonly PuppeteerManager _puppeteer;
     private readonly CacheStateManager _cacheManager;
-    private readonly MainConfig _config;
 
     public CallbackHandler(
         ILogger<CallbackHandler> logger,
@@ -57,7 +56,6 @@ public sealed class CallbackHandler : DisposableMediatorSubscriberBase
         _puppeteer = aliasManager;
         _cacheManager = cacheManager;
         _provider = provider;
-        _config = config;
     }
 
     private bool PostActionMsg(string enactor, InteractionType type, string message)
@@ -372,7 +370,7 @@ public sealed class CallbackHandler : DisposableMediatorSubscriberBase
 
         // apply the gag, and it's visual updates.
         if (_gags.ApplyGag(layer, newData.GagItem, "Mimic", out var gagItem))
-            await _cacheManager.AddGagItem(gagItem, layer, "Mimic", _config.Current.CursedItemsApplyTraits && item.ApplyTraits);
+            await _cacheManager.AddGagItem(gagItem, layer, "Mimic");
 
         // Lock it immediately.
         _gags.LockGag(layer, newData, "Mimic");

--- a/ProjectGagSpeak/State/Handlers/GlamourHandler.cs
+++ b/ProjectGagSpeak/State/Handlers/GlamourHandler.cs
@@ -17,9 +17,11 @@ public class GlamourHandler
     private SemaphoreSlim _applySlim = new SemaphoreSlim(1, 1);
     private IpcBlockReason _ipcBlocker = IpcBlockReason.None;
     
-    private readonly Dictionary<EquipSlot, (List<EquipItem> Released, int Attempts)> _pendingRestores = new();
+    private readonly Dictionary<EquipSlot, (List<EquipItem> Released, int Attempts, DateTime Seen)> _pendingRestores = new();
     private readonly Dictionary<MetaIndex, (TriStateBool Released, int Attempts)> _pendingMetaRestores = new();
     private const int MaxRestoreAttempts = 3;
+    private static readonly TimeSpan PendingRestoreTtl = TimeSpan.FromMinutes(3);
+    private readonly Dictionary<EquipSlot, EquipItem> _lastSeenEquipment = new();
 
     public GlamourHandler(ILogger<GlamourHandler> logger, IpcCallerGlamourer ipc, GlamourCache cache)
     {
@@ -119,6 +121,7 @@ public class GlamourHandler
             // Nothing left to reconcile against once the unbound snapshot is gone.
             _pendingRestores.Clear();
             _pendingMetaRestores.Clear();
+            _lastSeenEquipment.Clear();
         });
     }
 
@@ -192,8 +195,16 @@ public class GlamourHandler
             var stuckSlots = new List<EquipSlot>();
             var needsReapply = false;
 
-            foreach (var (slot, (released, attempts)) in _pendingRestores.ToList())
+            foreach (var (slot, (released, attempts, seen)) in _pendingRestores.ToList())
             {
+                if (DateTime.UtcNow - seen > PendingRestoreTtl)
+                {
+                    _logger.LogDebug($"Glamour reconciliation: slot {slot} went unconfirmed for over " +
+                        $"{PendingRestoreTtl.TotalMinutes} minutes, dropping.", LoggerType.IpcGlamourer);
+                    _pendingRestores.Remove(slot);
+                    continue;
+                }
+
                 if (!live.ParsedEquipment.TryGetValue(slot, out var actual))
                 {
                     _logger.LogDebug($"Glamour reconciliation: slot {slot} missing from live state, still watching it.", LoggerType.IpcGlamourer);
@@ -219,7 +230,7 @@ public class GlamourHandler
 
                     _logger.LogWarning($"Glamour reconciliation: slot {slot} should show [{forced.GameItem.Name}], " +
                         $"reapplying (attempt {attempts + 1}/{MaxRestoreAttempts}).", LoggerType.IpcGlamourer);
-                    _pendingRestores[slot] = (released, attempts + 1);
+                    _pendingRestores[slot] = (released, attempts + 1, seen);
                     needsReapply = true;
                     continue;
                 }
@@ -241,7 +252,7 @@ public class GlamourHandler
 
                 _logger.LogWarning($"Glamour reconciliation: slot {slot} still stuck on [{actual.Name}], " +
                     $"retrying restore (attempt {attempts + 1}/{MaxRestoreAttempts}).", LoggerType.IpcGlamourer);
-                _pendingRestores[slot] = (released, attempts + 1);
+                _pendingRestores[slot] = (released, attempts + 1, seen);
                 stuckSlots.Add(slot);
             }
 
@@ -320,9 +331,45 @@ public class GlamourHandler
         };
 
     /// <summary> Should only ever be used by the GlamourListener. </summary>
-    /// <remarks> Handled safely through a SemaphoreSlim. </remarks>
+    /// <remarks>
+    ///     Handled safely through a SemaphoreSlim.
+    /// </remarks>
     public async Task UpdateGlamourCacheSlim(bool reapply)
-        => await ExecuteWithSemaphore(() => UpdateGlamourInternal(false, reapply));
+        => await ExecuteWithSemaphore(() =>
+        {
+            if (_ipc.GetActorState() is { } liveObj)
+                DropPlayerChangedPendingRestores(new GlamourActorState(liveObj));
+            // Cache before applying so the player's manual choice is absorbed into the unbound state,
+            // otherwise a later restore would push whatever they were wearing before this change.
+            return UpdateGlamourInternal(true, reapply);
+        });
+
+    /// <summary>
+    ///     Clears pending restore tracking for slots changed outside this handler.
+    ///     <para>
+    ///     A genuinely stuck slot does not emit a Glamourer event because the item never changes.
+    ///     When an event is received here, the change did not originate from this handler, so the slot
+    ///     was changed externally, typically by the player.
+    ///     </para>
+    /// </summary>
+    /// <remarks>
+    ///     <see cref="StateChangeType.Equip"/> does not say which slot moved, so it is recovered by
+    ///     diffing against <see cref="_lastSeenEquipment"/>.
+    /// </remarks>
+    private void DropPlayerChangedPendingRestores(GlamourActorState live)
+    {
+        foreach (var (slot, item) in live.ParsedEquipment)
+        {
+            if (_lastSeenEquipment.TryGetValue(slot, out var prev) && prev.Equals(item))
+                continue;
+
+            if (_pendingRestores.Remove(slot))
+                _logger.LogDebug($"Glamour reconciliation: slot {slot} was changed by the player to " +
+                    $"[{item.Name}], no longer treating it as stuck.", LoggerType.IpcGlamourer);
+
+            _lastSeenEquipment[slot] = item;
+        }
+    }
 
     /// <summary> Should only ever be used by the GlamourListener. </summary>
     /// <remarks> Handled safely through a SemaphoreSlim. </remarks>
@@ -385,41 +432,60 @@ public class GlamourHandler
     ///     Restore slots no longer present in _finalGlamour from <see cref="_cache"/>, then reapplies what is still active.
     /// </summary>
     /// <remarks>
-    ///     Each released slot is recorded in <see cref="_pendingRestores"/> first, so that if this
-    ///     push silently fails to reach Glamourer the slot does not stay stuck forever.
+    ///     Each slot is added to <see cref="_pendingRestores"/> before the restore is pushed to Glamourer.
+    ///     This ensures a failed or unconfirmed push can be retried instead of leaving the slot stuck.
     /// </remarks>
     private async Task RestoreAndReapply(bool forceCacheCall, IReadOnlyDictionary<EquipSlot, EquipItem> slotsToRestore)
     {
-        foreach (var (slot, releasedItem) in slotsToRestore)
+        var results = await Task.WhenAll(slotsToRestore
+            .Select(async kvp => (Slot: kvp.Key, Released: kvp.Value, Confirmed: await RestoreSlot(kvp.Key))));
+
+        foreach (var (slot, releasedItem, confirmed) in results)
         {
+            if (confirmed || RestoresToSameItem(slot, releasedItem))
+                continue;
+
             if (_pendingRestores.TryGetValue(slot, out var pending))
             {
                 // An earlier release on this slot is still unconfirmed, so keep watching for that item
                 // too, and do not hand the slot a fresh attempt budget.
                 if (!pending.Released.Any(i => i.Equals(releasedItem)))
                     pending.Released.Add(releasedItem);
-                _pendingRestores[slot] = pending;
+                _pendingRestores[slot] = (pending.Released, pending.Attempts, DateTime.UtcNow);
             }
             else
-                _pendingRestores[slot] = ([releasedItem], 0);
+                _pendingRestores[slot] = ([releasedItem], 0, DateTime.UtcNow);
+
+            _lastSeenEquipment[slot] = releasedItem;
         }
 
-        await Task.WhenAll(slotsToRestore.Keys.Select(RestoreSlot));
         _logger.LogDebug($"Restored Glamourer Slots to last applied base value.", LoggerType.IpcGlamourer);
         // Now reapply the cache.
         _logger.LogDebug("Reapplying Glamourer Cache", LoggerType.IpcGlamourer);
         await ApplyGlamourCache(forceCacheCall);
     }
 
-    /// <summary> Pushes a single slot back to its last known unbound appearance. </summary>
-    private Task RestoreSlot(EquipSlot slot)
-    {
-        if (_cache.LastUnboundState.RecoverSlot(slot, out var itemId, out var stain, out var stain2))
-            return _ipc.SetClientItemSlot((ApiEquipSlot)slot, itemId, [stain, stain2], 0);
+    /// <summary> True when restoring <paramref name="slot"/> would put back the very item being released. </summary>
+    private bool RestoresToSameItem(EquipSlot slot, EquipItem released)
+        => _cache.LastUnboundState.RecoverSlot(slot, out var itemId, out _, out _) && itemId == released.Id.Id;
 
-        // Nothing to restore to. ReconcileWithActualState will notice the slot is still stuck and retry.
-        _logger.LogWarning($"Failed to restore slot {slot}, no data found in Glamourer cache.", LoggerType.IpcGlamourer);
-        return Task.CompletedTask;
+    /// <summary> Pushes a single slot back to its last known unbound appearance. </summary>
+    /// <returns> Whether Glamourer confirmed the push; false means it may not have taken effect. </returns>
+    private async Task<bool> RestoreSlot(EquipSlot slot)
+    {
+        if (!_cache.LastUnboundState.RecoverSlot(slot, out var itemId, out var stain, out var stain2))
+        {
+            // Nothing to restore to. ReconcileWithActualState will notice the slot is still stuck and retry.
+            _logger.LogWarning($"Failed to restore slot {slot}, no data found in Glamourer cache.", LoggerType.IpcGlamourer);
+            return false;
+        }
+
+        var result = await _ipc.SetClientItemSlot((ApiEquipSlot)slot, itemId, [stain, stain2], 0);
+        if (result is not (GlamourerApiEc.Success or GlamourerApiEc.NothingDone))
+            return false;
+
+        _lastSeenEquipment[slot] = ItemSvc.Resolve(slot, itemId);
+        return true;
     }
 
     /// <summary> 

--- a/ProjectGagSpeak/State/Handlers/GlamourHandler.cs
+++ b/ProjectGagSpeak/State/Handlers/GlamourHandler.cs
@@ -16,6 +16,10 @@ public class GlamourHandler
 
     private SemaphoreSlim _applySlim = new SemaphoreSlim(1, 1);
     private IpcBlockReason _ipcBlocker = IpcBlockReason.None;
+    
+    private readonly Dictionary<EquipSlot, (List<EquipItem> Released, int Attempts)> _pendingRestores = new();
+    private readonly Dictionary<MetaIndex, (TriStateBool Released, int Attempts)> _pendingMetaRestores = new();
+    private const int MaxRestoreAttempts = 3;
 
     public GlamourHandler(ILogger<GlamourHandler> logger, IpcCallerGlamourer ipc, GlamourCache cache)
     {
@@ -98,13 +102,24 @@ public class GlamourHandler
         => _cache.RemoveMeta(keys);
 
     /// <summary> Clears the Caches contents and updates the visuals after. </summary>
+    /// <remarks> Runs inside the SemaphoreSlim so the cache wipe cannot run midway through another operation. </remarks>
     public async Task ClearCache()
     {
         _logger.LogDebug("Clearing Glamour Cache.");
-        _cache.ClearCaches();
-        await UpdateCaches();
-        // After we clear out the cache and update them to their recovered state we should clear the unbound cache out
-        _cache.CacheUnboundState(GlamourActorState.Empty);
+        await ExecuteWithSemaphore(async () =>
+        {
+            _cache.ClearCaches();
+            // The internals are called directly here, as UpdateCaches would re-enter this same semaphore.
+            await Task.WhenAll(
+                UpdateMetaInternal(false, true),
+                UpdateGlamourInternal(false, true)
+            );
+            // After we clear out the cache and update them to their recovered state we should clear the unbound cache out
+            _cache.CacheUnboundState(GlamourActorState.Empty);
+            // Nothing left to reconcile against once the unbound snapshot is gone.
+            _pendingRestores.Clear();
+            _pendingMetaRestores.Clear();
+        });
     }
 
     /// <summary> Use this as your go-to update method for everything outside of IPC calls. </summary>
@@ -141,6 +156,168 @@ public class GlamourHandler
             _logger.LogInformation($"Reapplied Cache Updates Successfully!");
         });
     }
+
+    /// <summary>
+    ///     Self-heal for stuck glamour. <para />
+    ///     When a restriction is released we push the slot back to its unbound appearance, but that
+    ///     IPC call can silently fail to run - and once released, the slot is gone from
+    ///     <see cref="GlamourCache.FinalGlamour"/>, so nothing ever notices it is still showing
+    ///     the released item. This compares <see cref="_pendingRestores"/> against Glamourer's live state
+    ///     and retries any slot that is verifiably still stuck.
+    /// </summary>
+    /// <remarks> Intended to be called periodically (e.g. once a minute). Runs through the SemaphoreSlim. </remarks>
+    public async Task ReconcileWithActualState()
+    {
+        await ExecuteWithSemaphore(async () =>
+        {
+            if (_pendingRestores.Count is 0 && _pendingMetaRestores.Count is 0)
+            {
+                _logger.LogTrace("Glamour reconciliation: nothing pending.", LoggerType.IpcGlamourer);
+                return;
+            }
+
+            if (_ipc.GetActorState() is not { } liveObj)
+            {
+                _logger.LogTrace("Glamour reconciliation: actor state unavailable, skipping.", LoggerType.IpcGlamourer);
+                return;
+            }
+
+            var live = new GlamourActorState(liveObj);
+            if (live.ParsedEquipment.Count is 0)
+            {
+                _logger.LogDebug("Glamour reconciliation: live state had no equipment, skipping.", LoggerType.IpcGlamourer);
+                return;
+            }
+
+            var stuckSlots = new List<EquipSlot>();
+            var needsReapply = false;
+
+            foreach (var (slot, (released, attempts)) in _pendingRestores.ToList())
+            {
+                if (!live.ParsedEquipment.TryGetValue(slot, out var actual))
+                {
+                    _logger.LogDebug($"Glamour reconciliation: slot {slot} missing from live state, still watching it.", LoggerType.IpcGlamourer);
+                    continue;
+                }
+
+                if (_cache.FinalGlamour.TryGetValue(slot, out var forced))
+                {
+                    if (actual.Equals(forced.GameItem))
+                    {
+                        _logger.LogTrace($"Glamour reconciliation: slot {slot} re-forced and correct.", LoggerType.IpcGlamourer);
+                        _pendingRestores.Remove(slot);
+                        continue;
+                    }
+
+                    if (attempts >= MaxRestoreAttempts)
+                    {
+                        _logger.LogError($"Glamour reconciliation: slot {slot} still not showing forced item " +
+                            $"[{forced.GameItem.Name}] after {attempts} attempts, giving up.", LoggerType.IpcGlamourer);
+                        _pendingRestores.Remove(slot);
+                        continue;
+                    }
+
+                    _logger.LogWarning($"Glamour reconciliation: slot {slot} should show [{forced.GameItem.Name}], " +
+                        $"reapplying (attempt {attempts + 1}/{MaxRestoreAttempts}).", LoggerType.IpcGlamourer);
+                    _pendingRestores[slot] = (released, attempts + 1);
+                    needsReapply = true;
+                    continue;
+                }
+                
+                if (!released.Any(i => i.Equals(actual)))
+                {
+                    _logger.LogTrace($"Glamour reconciliation: slot {slot} restored correctly.", LoggerType.IpcGlamourer);
+                    _pendingRestores.Remove(slot);
+                    continue;
+                }
+                
+                if (attempts >= MaxRestoreAttempts)
+                {
+                    _logger.LogError($"Glamour reconciliation: slot {slot} still stuck on [{actual.Name}] after " +
+                        $"{attempts} attempts, giving up to avoid fighting the player.", LoggerType.IpcGlamourer);
+                    _pendingRestores.Remove(slot);
+                    continue;
+                }
+
+                _logger.LogWarning($"Glamour reconciliation: slot {slot} still stuck on [{actual.Name}], " +
+                    $"retrying restore (attempt {attempts + 1}/{MaxRestoreAttempts}).", LoggerType.IpcGlamourer);
+                _pendingRestores[slot] = (released, attempts + 1);
+                stuckSlots.Add(slot);
+            }
+
+            foreach (var (metaIdx, (released, attempts)) in _pendingMetaRestores.ToList())
+            {
+                var liveVal = MetaStateFor(live.MetaStates, metaIdx);
+                var baseVal = MetaStateFor(_cache.LastUnboundState.MetaStates, metaIdx);
+                
+                if (MetaStateFor(_cache.FinalMeta, metaIdx).HasValue || !liveVal.Equals(released))
+                {
+                    _pendingMetaRestores.Remove(metaIdx);
+                    continue;
+                }
+
+                if (attempts >= MaxRestoreAttempts)
+                {
+                    _logger.LogError($"Glamour reconciliation: {metaIdx} still stuck on ({released}) after " +
+                        $"{attempts} attempts, giving up.", LoggerType.IpcGlamourer);
+                    _pendingMetaRestores.Remove(metaIdx);
+                    continue;
+                }
+                
+                if ((bool?)baseVal is not { } restoreTo)
+                {
+                    _logger.LogDebug($"Glamour reconciliation: {metaIdx} stuck on ({released}) but the unbound state " +
+                        "has no value to restore to, waiting.", LoggerType.IpcGlamourer);
+                    continue;
+                }
+
+                _logger.LogWarning($"Glamour reconciliation: {metaIdx} still stuck on ({released}), " +
+                    $"retrying restore (attempt {attempts + 1}/{MaxRestoreAttempts}).", LoggerType.IpcGlamourer);
+                _pendingMetaRestores[metaIdx] = (released, attempts + 1);
+                await _ipc.SetMetaStates(MetaFlagFor(metaIdx), restoreTo);
+            }
+
+            if (stuckSlots.Count is 0 && !needsReapply)
+                return;
+
+            // Deliberately NOT cacheBeforeApply: We do not trust the live state, so
+            // re-snapshotting it would bake the stuck item in as the slot's base appearance.
+            if (stuckSlots.Count > 0)
+                await Task.WhenAll(stuckSlots.Select(RestoreSlot));
+            await ApplyGlamourCache(false);
+        });
+    }
+
+    /// <summary>
+    ///     Records a released meta flag so <see cref="ReconcileWithActualState"/> can verify the restore occurred.
+    /// </summary>
+    /// <remarks>
+    ///     Skipped when nothing was actually being forced, or when the unbound base already matches the
+    ///     forced value
+    /// </remarks>
+    private void TrackPendingMeta(MetaIndex metaIdx, TriStateBool released, TriStateBool baseValue)
+    {
+        if (!released.HasValue || baseValue.Equals(released))
+            return;
+        _pendingMetaRestores[metaIdx] = (released, 0);
+    }
+
+    private static TriStateBool MetaStateFor(MetaDataStruct meta, MetaIndex metaIdx)
+        => metaIdx switch
+        {
+            MetaIndex.HatState => meta.Headgear,
+            MetaIndex.VisorState => meta.Visor,
+            MetaIndex.WeaponState => meta.Weapon,
+            _ => TriStateBool.Null,
+        };
+
+    private static MetaFlag MetaFlagFor(MetaIndex metaIdx)
+        => metaIdx switch
+        {
+            MetaIndex.HatState => MetaFlag.HatState,
+            MetaIndex.VisorState => MetaFlag.VisorState,
+            _ => MetaFlag.WeaponState,
+        };
 
     /// <summary> Should only ever be used by the GlamourListener. </summary>
     /// <remarks> Handled safely through a SemaphoreSlim. </remarks>
@@ -182,12 +359,14 @@ public class GlamourHandler
     /// </summary>
     private async Task UpdateMetaInternal(bool forceCacheCall, bool reapply)
     {
+        // Capture what we were forcing BEFORE the update, so we can flag what must no longer be showing.
+        var wasForcing = _cache.FinalMeta;
         // Update the final cache. `removedSlots` contains slots that are no longer restricted after the change.
         if (_cache.UpdateFinalMetaCache(out bool noHat, out bool noVisor, out bool noWeapon))
         {
             _logger.LogDebug($"Final MetaState Cache was updated!", LoggerType.VisualCache);
             if (noHat || noVisor || noWeapon)
-                await RestoreMetaAndReapply(forceCacheCall, noHat, noVisor, noWeapon);
+                await RestoreMetaAndReapply(forceCacheCall, wasForcing, noHat, noVisor, noWeapon);
             else
                 await ApplyMetaCache(forceCacheCall);
             return;
@@ -202,26 +381,45 @@ public class GlamourHandler
         _logger.LogTrace("No change in Final MetaState Cache.", LoggerType.VisualCache);
     }
 
-    /// <summary> 
+    /// <summary>
     ///     Restore slots no longer present in _finalGlamour from <see cref="_cache"/>, then reapplies what is still active.
     /// </summary>
-    private async Task RestoreAndReapply(bool forceCacheCall, IEnumerable<EquipSlot> slotsToRestore)
+    /// <remarks>
+    ///     Each released slot is recorded in <see cref="_pendingRestores"/> first, so that if this
+    ///     push silently fails to reach Glamourer the slot does not stay stuck forever.
+    /// </remarks>
+    private async Task RestoreAndReapply(bool forceCacheCall, IReadOnlyDictionary<EquipSlot, EquipItem> slotsToRestore)
     {
-        await Task.WhenAll(slotsToRestore
-            .Select(slot =>
+        foreach (var (slot, releasedItem) in slotsToRestore)
+        {
+            if (_pendingRestores.TryGetValue(slot, out var pending))
             {
-                if (_cache.LastUnboundState.RecoverSlot(slot, out var itemId, out var stain, out var stain2))
-                    return _ipc.SetClientItemSlot((ApiEquipSlot)slot, itemId, [stain, stain2], 0);
-                else
-                {
-                    _logger.LogWarning($"Failed to restore slot {slot}, no data found in Glamourer cache.", LoggerType.IpcGlamourer);
-                    return Task.CompletedTask;
-                }
-            }));
+                // An earlier release on this slot is still unconfirmed, so keep watching for that item
+                // too, and do not hand the slot a fresh attempt budget.
+                if (!pending.Released.Any(i => i.Equals(releasedItem)))
+                    pending.Released.Add(releasedItem);
+                _pendingRestores[slot] = pending;
+            }
+            else
+                _pendingRestores[slot] = ([releasedItem], 0);
+        }
+
+        await Task.WhenAll(slotsToRestore.Keys.Select(RestoreSlot));
         _logger.LogDebug($"Restored Glamourer Slots to last applied base value.", LoggerType.IpcGlamourer);
         // Now reapply the cache.
         _logger.LogDebug("Reapplying Glamourer Cache", LoggerType.IpcGlamourer);
         await ApplyGlamourCache(forceCacheCall);
+    }
+
+    /// <summary> Pushes a single slot back to its last known unbound appearance. </summary>
+    private Task RestoreSlot(EquipSlot slot)
+    {
+        if (_cache.LastUnboundState.RecoverSlot(slot, out var itemId, out var stain, out var stain2))
+            return _ipc.SetClientItemSlot((ApiEquipSlot)slot, itemId, [stain, stain2], 0);
+
+        // Nothing to restore to. ReconcileWithActualState will notice the slot is still stuck and retry.
+        _logger.LogWarning($"Failed to restore slot {slot}, no data found in Glamourer cache.", LoggerType.IpcGlamourer);
+        return Task.CompletedTask;
     }
 
     /// <summary> 
@@ -247,8 +445,15 @@ public class GlamourHandler
         _logger.LogTrace("Applied Active Slots to Glamour", LoggerType.IpcGlamourer);
     }
 
-    private async Task RestoreMetaAndReapply(bool forceCacheCall, bool restoreHat, bool restoreVisor, bool restoreWeapon)
+    private async Task RestoreMetaAndReapply(bool forceCacheCall, MetaDataStruct wasForcing, bool restoreHat, bool restoreVisor, bool restoreWeapon)
     {
+        if (restoreHat)
+            TrackPendingMeta(MetaIndex.HatState, wasForcing.Headgear, _cache.LastUnboundState.MetaStates.Headgear);
+        if (restoreVisor)
+            TrackPendingMeta(MetaIndex.VisorState, wasForcing.Visor, _cache.LastUnboundState.MetaStates.Visor);
+        if (restoreWeapon)
+            TrackPendingMeta(MetaIndex.WeaponState, wasForcing.Weapon, _cache.LastUnboundState.MetaStates.Weapon);
+
         // If we are restoring the hat, visor or weapon, we need to restore the slots.
         if (restoreHat && (bool?)_cache.LastUnboundState.MetaStates.Headgear is { } newVal)
             await _ipc.SetMetaStates(MetaFlag.HatState, newVal);

--- a/ProjectGagSpeak/State/Handlers/GlamourHandler.cs
+++ b/ProjectGagSpeak/State/Handlers/GlamourHandler.cs
@@ -582,11 +582,20 @@ public class GlamourHandler
             // Schedule the re-enabling of glamour change events using RunOnFrameworkTickDelayed to offset Glamourer.)
             try
             {
-                await Svc.Framework.RunOnTick(() =>
+                // If we are unloading, don't attempt to await or else we will deadlock the client
+                if (Svc.IsUnloading)
                 {
                     _ipcBlocker &= ~IpcBlockReason.SemaphoreTask;
-                    _logger.LogDebug($"Releasing Semaphore Wait, Remaining Blockers: {_ipcBlocker.ToString()}", LoggerType.IpcGlamourer);
-                }, delayTicks: 1);
+                    _logger.LogDebug($"Releasing Semaphore Wait (unloading), Remaining Blockers: {_ipcBlocker.ToString()}", LoggerType.IpcGlamourer);
+                }
+                else
+                {
+                    await Svc.Framework.RunOnTick(() =>
+                    {
+                        _ipcBlocker &= ~IpcBlockReason.SemaphoreTask;
+                        _logger.LogDebug($"Releasing Semaphore Wait, Remaining Blockers: {_ipcBlocker.ToString()}", LoggerType.IpcGlamourer);
+                    }, delayTicks: 1);
+                }
             }
             catch (TaskCanceledException) { /* CONSUME */ }
 

--- a/ProjectGagSpeak/State/Managers/CacheManagers/CacheStateManager.cs
+++ b/ProjectGagSpeak/State/Managers/CacheManagers/CacheStateManager.cs
@@ -294,12 +294,10 @@ public class CacheStateManager : IHostedService
 
     /// <summary> Adds a GagItem's visual properties to the cache at the defined layer. </summary>
     /// <remarks> Changes are immediately reflected and updated to the player. </remarks>
-    public async Task AddGagItem(GarblerRestriction item, int layerIdx, string enabler)
+    public async Task AddGagItem(GarblerRestriction item, int layerIdx, string enabler, bool applyTraits = true)
     {
         _logger.LogDebug($"Adding ({item.GagType.GagName()}) at layer {layerIdx}, enabled by ({enabler}).");
         var key = new CombinedCacheKey(ManagerPriority.Gags, layerIdx, enabler, item.GagType.GagName());
-        
-        var applyTraits = enabler != "Mimic" || _config.Current.CursedItemsApplyTraits;
         
         var tasks = new List<Task>
         {

--- a/ProjectGagSpeak/State/Managers/CacheManagers/CacheStateManager.cs
+++ b/ProjectGagSpeak/State/Managers/CacheManagers/CacheStateManager.cs
@@ -298,13 +298,17 @@ public class CacheStateManager : IHostedService
     {
         _logger.LogDebug($"Adding ({item.GagType.GagName()}) at layer {layerIdx}, enabled by ({enabler}).");
         var key = new CombinedCacheKey(ManagerPriority.Gags, layerIdx, enabler, item.GagType.GagName());
-
+        
+        var applyTraits = enabler != "Mimic" || _config.Current.CursedItemsApplyTraits;
+        
         var tasks = new List<Task>
         {
             AddLociItem(key, item.LociData),
-            AddTraits(key, item.Traits),
             AddArousalStrength(key, item.Arousal)
         };
+        
+        if (applyTraits)
+            tasks.Add(AddTraits(key, item.Traits));
 
         if (item.IsEnabled)
         {

--- a/ProjectGagSpeak/State/Managers/CacheManagers/CacheStateManager.cs
+++ b/ProjectGagSpeak/State/Managers/CacheManagers/CacheStateManager.cs
@@ -124,9 +124,28 @@ public class CacheStateManager : IHostedService
         bool anyRequestedRedraw = false;
         _gags.LoadServerData(connectionDto.GagData);
         _logger.LogInformation("------ Syncing Gag Data to Cache ------");
+        // Gag slots enabled by "Mimic" are cursed loot gags, and are cached through the cursed loot system instead.
+        var cursedGagSlots = new Dictionary<int, CursedGagItem>();
         foreach (var (layer, gagItem) in _gags.ActiveItems)
         {
             var serverItem = _gags.ServerGagData!.GagSlots[layer];
+            if (serverItem.Enabler == "Mimic")
+            {
+                // Locate the cursed loot item this gag slot belongs to, favoring ones already marked as applied.
+                var lootItem = _cursedItems.Storage.OfType<CursedGagItem>()
+                    .Where(c => c.RefItem?.GagType == gagItem.GagType && !cursedGagSlots.ContainsValue(c))
+                    .OrderByDescending(c => c.IsActive())
+                    .FirstOrDefault();
+                if (lootItem is not null)
+                {
+                    // if the loot lost its applied state (config desync), restore it from the slot's mimic timer.
+                    if (!lootItem.IsActive())
+                        _cursedItems.ActivateItem(lootItem, serverItem.Timer);
+                    cursedGagSlots[layer] = lootItem;
+                    continue;
+                }
+                _logger.LogWarning($"No CursedGagItem found for Mimic-applied gag ({gagItem.GagType.GagName()}), treating as a normal gag.");
+            }
             _logger.LogDebug($"Adding ({gagItem.GagType.GagName()}) at layer {layer}, which was enabled by {serverItem.Enabler}.");
 
             var key = new CombinedCacheKey(ManagerPriority.Gags, layer, serverItem.Enabler, gagItem.GagType.GagName());
@@ -137,11 +156,17 @@ public class CacheStateManager : IHostedService
                 _modHandler.TryAddModToCache(key, gagItem.Mod);
             }
             _lociHandler.TryAddLociItemToCache(key, gagItem.LociData);
-            _traitsHandler.TryAddTraitsToCache(key, gagItem.Traits);
+            _traitsHandler.TryAddTraitsToCache(key, GagTraitsForEnabler(gagItem, serverItem.Enabler));
             _cplusHandler.TryAddToCache(key, gagItem.CPlusProfile);
             _arousalHandler.TryAddArousalToCache(key, gagItem.Arousal);
 
             anyRequestedRedraw |= gagItem.DoRedraw;
+        }
+        // Deactivate any applied cursed gags that no longer hold a gag slot on the server. (expired while we were away)
+        foreach (var staleGag in _cursedItems.Storage.AppliedLootUnsorted.OfType<CursedGagItem>().Where(c => !cursedGagSlots.ContainsValue(c)).ToArray())
+        {
+            _logger.LogDebug($"Cursed Gag [{staleGag.Label}] was applied locally but holds no gag slot on the server, deactivating.");
+            _cursedItems.SetInactive(staleGag.Identifier);
         }
         _logger.LogInformation("------ Gag Data synced to Cache ------ ");
 
@@ -245,6 +270,26 @@ public class CacheStateManager : IHostedService
             anyRequestedRedraw |= item.DoRedraw;
         }
 
+        // Sync the cursed loot gags found during the gag data sync. (these use the gag slot layer, which never collides with cursed restriction keys)
+        foreach (var (layer, loot) in cursedGagSlots)
+        {
+            var refGag = loot.RefItem;
+            _logger.LogDebug($"Adding Cursed Gag [{loot.Label}] at gag layer {layer}.");
+            var key = new CombinedCacheKey(ManagerPriority.CursedLoot, layer, "Mimic", $"Cursed {loot.Label}");
+            if (refGag.IsEnabled)
+            {
+                _glamourHandler.TryAddGlamourToCache(key, refGag.Glamour);
+                _glamourHandler.TryAddMetaToCache(key, new(refGag.HeadgearState, refGag.VisorState));
+                _modHandler.TryAddModToCache(key, refGag.Mod);
+            }
+            _lociHandler.TryAddLociItemToCache(key, refGag.LociData);
+            _cplusHandler.TryAddToCache(key, refGag.CPlusProfile);
+            if (_config.Current.CursedItemsApplyTraits && loot.ApplyTraits)
+                _traitsHandler.TryAddTraitsToCache(key, refGag.Traits & ~(Traits.Immobile | Traits.Weighty));
+            _arousalHandler.TryAddArousalToCache(key, refGag.Arousal);
+
+            anyRequestedRedraw |= refGag.DoRedraw;
+        }
 
         _logger.LogInformation("------ Cursed Item Data synced to Cache ------ ");
 
@@ -302,7 +347,7 @@ public class CacheStateManager : IHostedService
         var tasks = new List<Task>
         {
             AddLociItem(key, item.LociData),
-            AddTraits(key, item.Traits),
+            AddTraits(key, GagTraitsForEnabler(item, enabler)),
             AddArousalStrength(key, item.Arousal)
         };
 
@@ -606,6 +651,52 @@ public class CacheStateManager : IHostedService
             _redrawAssist.RedrawObject();
     }
 
+    /// <summary> Adds a cursed loot gag's visual properties to the cache, keyed by the gag slot layer it occupies. </summary>
+    /// <remarks> The gag slot layers (0-2) never collide with the generated cursed restriction keys (1000+). </remarks>
+    public async Task AddCursedGagItem(CursedGagItem item, int layer)
+    {
+        _logger.LogDebug($"Adding Cursed Gag [{item.Label}] with ({item.Precedence}) precedence to gag layer {layer}.");
+        var refGag = item.RefItem;
+        var key = new CombinedCacheKey(ManagerPriority.CursedLoot, layer, "Mimic", $"Cursed {item.Label}");
+        var tasks = new List<Task>
+        {
+            AddLociItem(key, refGag.LociData),
+            AddArousalStrength(key, refGag.Arousal)
+        };
+        if (refGag.IsEnabled)
+        {
+            tasks.Add(AddGlamourMeta(key, refGag.Glamour, new(refGag.HeadgearState, refGag.VisorState)));
+            tasks.Add(AddModPreset(key, refGag.Mod));
+            tasks.Add(AddProfile(key, refGag.CPlusProfile));
+        }
+        if (_config.Current.CursedItemsApplyTraits && item.ApplyTraits)
+            tasks.Add(AddTraits(key, refGag.Traits & ~(Traits.Immobile | Traits.Weighty)));
+
+        // Run in parallel.
+        await TimedWhenAll($"[{key}]'s Visual Attributes added to caches", tasks);
+        // Handle Redraw afterwards
+        if (refGag.DoRedraw)
+            _redrawAssist.RedrawObject();
+    }
+
+    public async Task RemoveCursedGagItem(CursedGagItem item, int layer)
+    {
+        _logger.LogInformation($"Removing Cursed Gag [{item.Label}] from gag layer {layer}");
+        var key = new CombinedCacheKey(ManagerPriority.CursedLoot, layer, "Mimic", string.Empty);
+        // Remove and update in parallel.
+        await TimedWhenAll($"[{key}] removed from cache and base states restored",
+            RemoveGlamourMeta(key),
+            RemoveModPreset(key),
+            RemoveLociData(key),
+            RemoveProfile(key),
+            RemoveTraits(key),
+            RemoveArousalStrength(key)
+        );
+        // Handle Redraw afterwards
+        if (item.RefItem.DoRedraw)
+            _redrawAssist.RedrawObject();
+    }
+
     // Always use MainHub.UID for the applier so that we can track the updates easier.
     // Assumed SyncedData is valid.
     public async Task AddCollar(UserData enactor)
@@ -655,6 +746,11 @@ public class CacheStateManager : IHostedService
             RemoveLociData(key)
         );
     }
+
+    /// <summary> Gates a gag's traits when applied by a Mimic, so cursed loot gags never apply traits unrestricted. </summary>
+    private Traits GagTraitsForEnabler(GarblerRestriction gag, string enabler)
+        => enabler != "Mimic" ? gag.Traits
+            : _config.Current.CursedItemsApplyTraits ? gag.Traits & ~(Traits.Immobile | Traits.Weighty) : Traits.None;
 
     private async Task TimedWhenAll(string label, IEnumerable<Task> tasks)
     {

--- a/ProjectGagSpeak/State/Managers/CacheManagers/CacheStateManager.cs
+++ b/ProjectGagSpeak/State/Managers/CacheManagers/CacheStateManager.cs
@@ -75,12 +75,12 @@ public class CacheStateManager : IHostedService
         return Task.CompletedTask;
     }
 
-    public async Task StopAsync(CancellationToken cancellationToken)
+    public Task StopAsync(CancellationToken cancellationToken)
     {
         _logger.LogInformation("CacheStateManager stopping, clearing caches.");
         Svc.ClientState.Logout -= OnLogout;
-        await ClearCachesSafely().ConfigureAwait(false);
-        _stateLock.Dispose();
+        _ = ClearCachesSafely();
+        return Task.CompletedTask;
     }
 
     private void OnLogout(int type, int code) => _ = ClearCachesSafely();

--- a/ProjectGagSpeak/State/Managers/CacheManagers/CacheStateManager.cs
+++ b/ProjectGagSpeak/State/Managers/CacheManagers/CacheStateManager.cs
@@ -40,6 +40,11 @@ public class CacheStateManager : IHostedService
     private readonly ArousalService _arousalHandler;
     private readonly MainConfig _config;
 
+    // Guards every cache-mutating method below so that a cursed-loot expiry and a pair-triggered
+    // restraint/restriction change can never interleave their mutations of the shared, non-thread-safe
+    // GlamourCache/ModCache/etc. collections.
+    private readonly SemaphoreSlim _stateLock = new(1, 1);
+
     public CacheStateManager(ILogger<CacheStateManager> logger, IpcCallerPenumbra redrawAssist,
         GagRestrictionManager gags, RestrictionManager restrictions, RestraintManager restraints,
         CollarManager collar, CursedLootManager cursedItems, CustomizePlusHandler profiles, 
@@ -66,19 +71,47 @@ public class CacheStateManager : IHostedService
     public Task StartAsync(CancellationToken cancellationToken)
     {
         _logger.LogInformation("CacheStateManager started, listening for logout events.");
-        Svc.ClientState.Logout += (_, _) => ClearCaches();
+        Svc.ClientState.Logout += OnLogout;
         return Task.CompletedTask;
     }
 
-    public Task StopAsync(CancellationToken cancellationToken)
+    public async Task StopAsync(CancellationToken cancellationToken)
     {
         _logger.LogInformation("CacheStateManager stopping, clearing caches.");
-        Svc.ClientState.Logout -= (_, _) => ClearCaches();
-        ClearCaches();
-        return Task.CompletedTask;
+        Svc.ClientState.Logout -= OnLogout;
+        await ClearCachesSafely().ConfigureAwait(false);
+        _stateLock.Dispose();
     }
 
-    private async void ClearCaches()
+    private void OnLogout(int type, int code) => _ = ClearCachesSafely();
+
+    /// <summary> Clears the caches, keeping any failure from escaping into an unobserved task. </summary>
+    private async Task ClearCachesSafely()
+    {
+        try
+        {
+            await ClearCaches().ConfigureAwait(false);
+        }
+        catch (Bagagwa ex)
+        {
+            _logger.LogError($"Failed to clear caches: {ex}");
+        }
+    }
+
+    private async Task WithStateLock(Func<Task> action)
+    {
+        await _stateLock.WaitAsync();
+        try
+        {
+            await action();
+        }
+        finally
+        {
+            _stateLock.Release();
+        }
+    }
+
+    private Task ClearCaches() => WithStateLock(async () =>
     {
         _logger.LogInformation("------- Clearing all caches on logout -------");
         await Task.WhenAll(
@@ -91,10 +124,10 @@ public class CacheStateManager : IHostedService
             _arousalHandler.ClearArousals()
         );
         _logger.LogInformation("------- All caches cleared -------");
-    }
+    });
 
     // going to need to make this not effect the collar restriction later, and maybe some other arousals!
-    public async Task ResetCachesDueToSafeword()
+    public Task ResetCachesDueToSafeword() => WithStateLock(async () =>
     {
         _logger.LogInformation("------- Resetting all caches due to safeword -------");
         _gags.LoadServerData(new CharaActiveGags());
@@ -114,10 +147,10 @@ public class CacheStateManager : IHostedService
         );
 
         _logger.LogInformation("------- All caches reset -------");
-    }
+    });
 
     // Keep in mind that while this looks heavy, everything uses .TryAdd, meaning duplicates will not be reapplied.
-    public async Task SyncWithServerData(ConnectionResponse connectionDto)
+    public Task SyncWithServerData(ConnectionResponse connectionDto) => WithStateLock(async () =>
     {
         var sw = Stopwatch.StartNew();
         // Sync all server gag data with the GagRestrictionManager.
@@ -335,11 +368,11 @@ public class CacheStateManager : IHostedService
             _redrawAssist.RedrawObject();
         sw.Stop();
         _logger.LogInformation($"------ All Updates & Visuals Applied in {sw.ElapsedMilliseconds}ms ------");
-    }
+    });
 
     /// <summary> Adds a GagItem's visual properties to the cache at the defined layer. </summary>
     /// <remarks> Changes are immediately reflected and updated to the player. </remarks>
-    public async Task AddGagItem(GarblerRestriction item, int layerIdx, string enabler)
+    public Task AddGagItem(GarblerRestriction item, int layerIdx, string enabler) => WithStateLock(async () =>
     {
         _logger.LogDebug($"Adding ({item.GagType.GagName()}) at layer {layerIdx}, enabled by ({enabler}).");
         var key = new CombinedCacheKey(ManagerPriority.Gags, layerIdx, enabler, item.GagType.GagName());
@@ -363,11 +396,11 @@ public class CacheStateManager : IHostedService
         // Handle Redraw afterwards
         if (item.DoRedraw)
             _redrawAssist.RedrawObject();
-    }
+    });
 
     /// <summary> Removes the visuals of a <see cref="GarblerRestriction"/> stored in the caches at a <paramref name="layerIdx"/></summary>
     /// <remarks> Changes are immidiately reflected and updated to the player. </remarks>
-    public async Task RemoveGagItem(GarblerRestriction item, int layerIdx)
+    public Task RemoveGagItem(GarblerRestriction item, int layerIdx) => WithStateLock(async () =>
     {
         _logger.LogDebug($"Removing ({item.GagType.GagName()}) from cache at layer {layerIdx}");
         var key = new CombinedCacheKey(ManagerPriority.Gags, layerIdx, string.Empty, item.GagType.GagName());
@@ -383,9 +416,9 @@ public class CacheStateManager : IHostedService
         // Handle Redraw afterwards
         if (item.DoRedraw)
             _redrawAssist.RedrawObject();
-    }
+    });
 
-    public async Task AddRestrictionItem(RestrictionItem item, int layerIdx, string enabler)
+    public Task AddRestrictionItem(RestrictionItem item, int layerIdx, string enabler) => WithStateLock(async () =>
     {
         _logger.LogDebug($"Adding Restriction ({item.Label}) at layer {layerIdx}, enabled by ({enabler}).");
         var key = new CombinedCacheKey(ManagerPriority.Restrictions, layerIdx, enabler, item.Label);
@@ -409,9 +442,9 @@ public class CacheStateManager : IHostedService
         // Handle Redraw afterwards
         if (item.DoRedraw)
             _redrawAssist.RedrawObject();
-    }
+    });
 
-    public async Task RemoveRestrictionItem(RestrictionItem item, int layerIdx)
+    public Task RemoveRestrictionItem(RestrictionItem item, int layerIdx) => WithStateLock(async () =>
     {
         _logger.LogInformation($"Removing Restriction [{item.Label}] from cache at layer {layerIdx}");
         var key = new CombinedCacheKey(ManagerPriority.Restrictions, layerIdx, string.Empty, item.Label);
@@ -428,9 +461,9 @@ public class CacheStateManager : IHostedService
         // Handle Redraw afterwards
         if (item.DoRedraw)
             _redrawAssist.RedrawObject();
-    }
+    });
 
-    public async Task AddRestraintSet(RestraintSet item, string enabler)
+    public Task AddRestraintSet(RestraintSet item, string enabler) => WithStateLock(async () =>
     {
         _logger.LogInformation($"Adding RestraintSet ({item.Label}), which was enabled by {enabler}.");
         var key = new CombinedCacheKey(ManagerPriority.Restraints, 0, enabler, item.Label);
@@ -455,9 +488,9 @@ public class CacheStateManager : IHostedService
         // Handle Redraw afterwards
         if (item.DoRedraw)
             _redrawAssist.RedrawObject();
-    }
+    });
 
-    public async Task SwapRestraintSetLayers(RestraintSet item, RestraintLayer added, RestraintLayer removed, string enactor)
+    public Task SwapRestraintSetLayers(RestraintSet item, RestraintLayer added, RestraintLayer removed, string enactor) => WithStateLock(async () =>
     {
         // If we want blindfolds and hypno to work on the applier, it will be hard to fix once reconnect since we wont know who applied each layer.
         // So for now, we are just going to restrict it to the enabler, or the enactor if the padlock is devotional.
@@ -502,9 +535,9 @@ public class CacheStateManager : IHostedService
             _arousalHandler.UpdateFinalCache(),
             _overlayHandler.UpdateCaches()
         );
-    }
+    });
 
-    public async Task AddRestraintSetLayers(RestraintSet item, RestraintLayer added, string enactor)
+    public Task AddRestraintSetLayers(RestraintSet item, RestraintLayer added, string enactor) => WithStateLock(async () =>
     {
         // If we want blindfolds and hypno to work on the applier, it will be hard to fix once reconnect since we wont know who applied each layer.
         // So for now, we are just going to restrict it to the enabler, or the enactor if the padlock is devotional.
@@ -539,11 +572,11 @@ public class CacheStateManager : IHostedService
             _arousalHandler.UpdateFinalCache(),
             _overlayHandler.UpdateCaches()
         );
-    }
+    });
 
     // I can almost guarantee that removing this without considering for any
     // active layers will cause issues, handle later, or restrict well.
-    public async Task RemoveRestraintSet(RestraintSet item, RestraintLayer removedLayers)
+    public Task RemoveRestraintSet(RestraintSet item, RestraintLayer removedLayers) => WithStateLock(async () =>
     {
         foreach (var idx in removedLayers.GetLayerIndices())
         {
@@ -571,11 +604,11 @@ public class CacheStateManager : IHostedService
         // Handle Redraw afterwards
         if (item.DoRedraw)
             _redrawAssist.RedrawObject();
-    }
+    });
 
 
     // Enabler here is only for logging purposes.
-    public async Task RemoveRestraintSetLayers(RestraintSet item, RestraintLayer removed)
+    public Task RemoveRestraintSetLayers(RestraintSet item, RestraintLayer removed) => WithStateLock(async () =>
     {
         _logger.LogInformation($"Removing RestraintSet ({item.Label}) from cache on layers ({removed})");
         // Add all enabled layers.
@@ -600,10 +633,10 @@ public class CacheStateManager : IHostedService
             _arousalHandler.UpdateFinalCache(),
             _overlayHandler.UpdateCaches()
         );
-    }
+    });
 
     // For CURSED ITEMS.
-    public async Task AddCursedItem(CursedRestrictionItem item, int layer)
+    public Task AddCursedItem(CursedRestrictionItem item, int layer) => WithStateLock(async () =>
     {
         _logger.LogDebug($"Adding CursedItem [{item.Label}] with ({item.Precedence}) precedence to layer {layer}.");
         var key = new CombinedCacheKey(ManagerPriority.CursedLoot, layer, "Mimic", $"Cursed {item.RefItem.Label}");
@@ -630,9 +663,9 @@ public class CacheStateManager : IHostedService
         // Handle Redraw afterwards
         if (item.RefItem.DoRedraw)
             _redrawAssist.RedrawObject();
-    }
+    });
 
-    public async Task RemoveCursedItem(CursedRestrictionItem item, int layer)
+    public Task RemoveCursedItem(CursedRestrictionItem item, int layer) => WithStateLock(async () =>
     {
         _logger.LogInformation($"Removing Cursed Item [{item.Label}] from layer {layer}");
         var key = new CombinedCacheKey(ManagerPriority.CursedLoot, layer, "Mimic", string.Empty);
@@ -649,11 +682,11 @@ public class CacheStateManager : IHostedService
         // Handle Redraw afterwards
         if (item.RefItem.DoRedraw)
             _redrawAssist.RedrawObject();
-    }
+    });
 
     /// <summary> Adds a cursed loot gag's visual properties to the cache, keyed by the gag slot layer it occupies. </summary>
     /// <remarks> The gag slot layers (0-2) never collide with the generated cursed restriction keys (1000+). </remarks>
-    public async Task AddCursedGagItem(CursedGagItem item, int layer)
+    public Task AddCursedGagItem(CursedGagItem item, int layer) => WithStateLock(async () =>
     {
         _logger.LogDebug($"Adding Cursed Gag [{item.Label}] with ({item.Precedence}) precedence to gag layer {layer}.");
         var refGag = item.RefItem;
@@ -677,9 +710,9 @@ public class CacheStateManager : IHostedService
         // Handle Redraw afterwards
         if (refGag.DoRedraw)
             _redrawAssist.RedrawObject();
-    }
+    });
 
-    public async Task RemoveCursedGagItem(CursedGagItem item, int layer)
+    public Task RemoveCursedGagItem(CursedGagItem item, int layer) => WithStateLock(async () =>
     {
         _logger.LogInformation($"Removing Cursed Gag [{item.Label}] from gag layer {layer}");
         var key = new CombinedCacheKey(ManagerPriority.CursedLoot, layer, "Mimic", string.Empty);
@@ -695,11 +728,11 @@ public class CacheStateManager : IHostedService
         // Handle Redraw afterwards
         if (item.RefItem.DoRedraw)
             _redrawAssist.RedrawObject();
-    }
+    });
 
     // Always use MainHub.UID for the applier so that we can track the updates easier.
     // Assumed SyncedData is valid.
-    public async Task AddCollar(UserData enactor)
+    public Task AddCollar(UserData enactor) => WithStateLock(async () =>
     {
         if (!_collar.IsActive || !_collar.ShowVisuals)
             return;
@@ -716,9 +749,9 @@ public class CacheStateManager : IHostedService
             AddModPreset(key, data.Mod),
             AddLociItem(key, new LociTuple(synced.StatusInfo))
         );
-    }
+    });
 
-    public async Task UpdateCollar(DataUpdateType type, UserData enactor)
+    public Task UpdateCollar(DataUpdateType type, UserData enactor) => WithStateLock(async () =>
     {
         if (_collar.SyncedData is not { } synced)
             return;
@@ -733,9 +766,9 @@ public class CacheStateManager : IHostedService
         await TimedWhenAll($"[{key}]'s Collar Visuals updated in caches", type is DataUpdateType.DyesChange
             ? UpdateGlamour(key, data.Glamour.Slot, new StainIds([synced.Dye1, synced.Dye2]))
             : UpdateLociData(key, new LociTuple(synced.StatusInfo)));
-    }
+    });
 
-    public async Task RemoveCollar(UserData enactor)
+    public Task RemoveCollar(UserData enactor) => WithStateLock(async () =>
     {
         _logger.LogDebug($"Removing Collar [{_collar.ClientCollar.Label}] Enacted by: {enactor.AliasOrUID} ({enactor.UID})");
         var key = new CombinedCacheKey(ManagerPriority.Collar, 0, string.Empty, _collar.ClientCollar.Label);
@@ -745,7 +778,13 @@ public class CacheStateManager : IHostedService
             RemoveModPreset(key),
             RemoveLociData(key)
         );
-    }
+    });
+
+    /// <summary>
+    ///     Diffs GagSpeak's cached final glamour/meta state against Glamourer's actual live actor
+    ///     state and re-applies corrective IPC calls if they've drifted apart.
+    /// </summary>
+    public Task ReconcileGlamourState() => _glamourHandler.ReconcileWithActualState();
 
     /// <summary> Gates a gag's traits when applied by a Mimic, so cursed loot gags never apply traits unrestricted. </summary>
     private Traits GagTraitsForEnabler(GarblerRestriction gag, string enabler)

--- a/ProjectGagSpeak/State/Managers/CacheManagers/CacheStateManager.cs
+++ b/ProjectGagSpeak/State/Managers/CacheManagers/CacheStateManager.cs
@@ -298,17 +298,13 @@ public class CacheStateManager : IHostedService
     {
         _logger.LogDebug($"Adding ({item.GagType.GagName()}) at layer {layerIdx}, enabled by ({enabler}).");
         var key = new CombinedCacheKey(ManagerPriority.Gags, layerIdx, enabler, item.GagType.GagName());
-        
-        var applyTraits = enabler != "Mimic" || _config.Current.CursedItemsApplyTraits;
-        
+
         var tasks = new List<Task>
         {
             AddLociItem(key, item.LociData),
+            AddTraits(key, item.Traits),
             AddArousalStrength(key, item.Arousal)
         };
-        
-        if (applyTraits)
-            tasks.Add(AddTraits(key, item.Traits));
 
         if (item.IsEnabled)
         {

--- a/ProjectGagSpeak/State/Managers/CacheManagers/CacheStateManager.cs
+++ b/ProjectGagSpeak/State/Managers/CacheManagers/CacheStateManager.cs
@@ -294,10 +294,12 @@ public class CacheStateManager : IHostedService
 
     /// <summary> Adds a GagItem's visual properties to the cache at the defined layer. </summary>
     /// <remarks> Changes are immediately reflected and updated to the player. </remarks>
-    public async Task AddGagItem(GarblerRestriction item, int layerIdx, string enabler, bool applyTraits = true)
+    public async Task AddGagItem(GarblerRestriction item, int layerIdx, string enabler)
     {
         _logger.LogDebug($"Adding ({item.GagType.GagName()}) at layer {layerIdx}, enabled by ({enabler}).");
         var key = new CombinedCacheKey(ManagerPriority.Gags, layerIdx, enabler, item.GagType.GagName());
+        
+        var applyTraits = enabler != "Mimic" || _config.Current.CursedItemsApplyTraits;
         
         var tasks = new List<Task>
         {

--- a/ProjectGagSpeak/State/Managers/CacheManagers/CursedLootManager.cs
+++ b/ProjectGagSpeak/State/Managers/CacheManagers/CursedLootManager.cs
@@ -133,6 +133,11 @@ public sealed class CursedLootManager : IHybridSavable
     public void AddFavorite(CursedItem loot) => _favorites.TryAddRestriction(FavoriteIdContainer.CursedLoot, loot.Identifier);
     public void RemoveFavorite(CursedItem loot) => _favorites.RemoveRestriction(FavoriteIdContainer.CursedLoot, loot.Identifier);
     #endregion Generic Methods
+    /// <summary> Feeds the chat garbler the gag types of all applied cursed loot gags. </summary>
+    /// <remarks> Required, as cursed loot gags garble through this list instead of the gag slots. </remarks>
+    private void SyncGarblerWithCursedGags()
+        => _gags.SetCursedLootGags(Storage.AppliedLootUnsorted.OfType<CursedGagItem>().Where(c => c.RefItem is not null).Select(c => c.RefItem.GagType));
+
     // Called from safeword service, deactivates all items.
     public void InvalidateAllActive()
     {
@@ -142,6 +147,7 @@ public sealed class CursedLootManager : IHybridSavable
             item.ReleaseTime = DateTimeOffset.MinValue;
         }
         _saver.Save(this);
+        SyncGarblerWithCursedGags();
     }
 
     public void ForceSave() => _saver.Save(this);
@@ -159,6 +165,7 @@ public sealed class CursedLootManager : IHybridSavable
         item.AppliedTime = DateTimeOffset.UtcNow;
         item.ReleaseTime = endTimeUtc;
         _saver.Save(this);
+        SyncGarblerWithCursedGags();
     }
 
     public void SetInactive(Guid lootId)
@@ -168,6 +175,7 @@ public sealed class CursedLootManager : IHybridSavable
         item.AppliedTime = DateTimeOffset.MinValue;
         item.ReleaseTime = DateTimeOffset.MinValue;
         _saver.Save(this);
+        SyncGarblerWithCursedGags();
     }
 
     public void SetLowerLimit(TimeSpan time)
@@ -281,6 +289,8 @@ public sealed class CursedLootManager : IHybridSavable
         }
         // run a save after the load.
         _saver.Save(this);
+        // feed the garbler any cursed gags that were applied when this config last saved. Might not need?
+        SyncGarblerWithCursedGags();
         _mediator.Publish(new ReloadFileSystem(GSModule.CursedLoot));
     }
 

--- a/ProjectGagSpeak/State/Managers/GagRestrictionsManager.cs
+++ b/ProjectGagSpeak/State/Managers/GagRestrictionsManager.cs
@@ -27,6 +27,7 @@ public sealed class GagRestrictionManager : IHybridSavable
     private StorageItemEditor<GarblerRestriction> _itemEditor = new();
     private CharaActiveGags? _serverGagData = null;
     private Dictionary<int, GarblerRestriction> _activeItems = new();
+    private IReadOnlyList<GagType> _cursedLootGags = [];
 
     public GagRestrictionManager(
         ILogger<GagRestrictionManager> logger,
@@ -65,8 +66,25 @@ public sealed class GagRestrictionManager : IHybridSavable
             if (slot.GagItem is not GagType.None && Storage.TryGetGag(slot.GagItem, out var item))
                 _activeItems.TryAdd(idx, item);
         // resync the active chat garbler data if any were set.
-        _muffler.UpdateGarblerLogic(serverData.CurrentGagNames(), MufflerService.MuffleType(serverData.GagSlots.Select(g => g.GagItem)));
+        RefreshGarblerLogic();
         _logger.LogInformation("Synchronized all Active GagSlots with Client-Side Manager.");
+    }
+
+    /// <summary> Updates the cursed loot gags fed to the chat garbler. </summary>
+    /// <remarks> Cursed loot gags garble through this list, and not the gag slots, as eventually they will no longer occupy one. </remarks>
+    public void SetCursedLootGags(IEnumerable<GagType> gags)
+    {
+        _cursedLootGags = gags.ToList();
+        RefreshGarblerLogic();
+    }
+
+    /// <summary> Rebuilds the chat garbler from the active gag slots and the applied cursed loot gags. </summary>
+    /// <remarks> Mimic-enabled slots are excluded; while cursed gags still occupy a server slot, they only garble via the cursed loot list. Will remove when the server no longer occupies a slot for cursed loot. </remarks>
+    private void RefreshGarblerLogic()
+    {
+        var slotGags = _serverGagData?.GagSlots.Where(s => s.Enabler != "Mimic").Select(s => s.GagItem) ?? [];
+        var allGags = slotGags.Concat(_cursedLootGags).Where(g => g is not GagType.None).Distinct().ToList();
+        _muffler.UpdateGarblerLogic(allGags.Select(g => g.GagName()).ToList(), MufflerService.MuffleType(allGags));
     }
 
     /// <summary> Begin the editing process, making a clone of the item we want to edit. </summary>
@@ -137,7 +155,7 @@ public sealed class GagRestrictionManager : IHybridSavable
 
         _logger.LogTrace($"Updating Garbler Logic for gag {newGag.GagName()} to layer {layer} by {enactor}");
         // Update the garbler logic to reflect the new gags.
-        _muffler.UpdateGarblerLogic(data.CurrentGagNames(), MufflerService.MuffleType(data.GagSlots.Select(g => g.GagItem)));
+        RefreshGarblerLogic();
         // Invoke the Mediator of this change.
         _mediator.Publish(new GagStateChanged(NewState.Enabled, layer, data.GagSlots[layer], enactor, MainHub.UID));
 
@@ -196,7 +214,7 @@ public sealed class GagRestrictionManager : IHybridSavable
         data.GagSlots[layer].GagItem = GagType.None;
         data.GagSlots[layer].Enabler = string.Empty;
         // Update the garbler logic to reflect the new gags.
-        _muffler.UpdateGarblerLogic(data.CurrentGagNames(), MufflerService.MuffleType(data.GagSlots.Select(g => g.GagItem)));
+        RefreshGarblerLogic();
         _mediator.Publish(new GagStateChanged(NewState.Disabled, layer, prev, enactor, MainHub.UID));
 
         // Update the affected visual states, if item is enabled.

--- a/ProjectGagSpeak/StaticServices.cs
+++ b/ProjectGagSpeak/StaticServices.cs
@@ -57,6 +57,13 @@ public class Svc
     [PluginService] public static ITextureProvider Texture { get; private set; } = null!;
     [PluginService] public static IToastGui Toasts { get; private set; } = null!;
     [PluginService] public static ITextureSubstitutionProvider TextureSubstitution { get; private set; } = null!;
+
+    /// <summary>
+    ///     Set the moment the plugin begins tearing down, before the host is stopped. <para />
+    ///     Dalamud disposes us on the framework thread, so anything that waits on a future framework
+    ///     tick (Framework.RunOnTick) can never complete during teardown. Check this before awaiting one.
+    /// </summary>
+    public static volatile bool IsUnloading;
 }
 
 /// <summary>


### PR DESCRIPTION
added thread safety to CacheStateManager.cs as there was a chance that timers expiring at the same time as updates of changed sets and restrictions from the server could cause items to be snapshot'd and stuck on a character. 

The actual change is c5c1a9ca9b596aa61e0713f316f7966ba7f72fdd

Requires: https://github.com/Project-GagSpeak/client/pull/160