### PR TITLE
fix: hardcore imprisonment not pathing correctly and spamming logs

### DIFF
--- a/ProjectGagSpeak/GameInternals/Detours/Static/MoveOverrides.cs
+++ b/ProjectGagSpeak/GameInternals/Detours/Static/MoveOverrides.cs
@@ -5,6 +5,7 @@ using Dalamud.Utility.Signatures;
 using FFXIVClientStructs.FFXIV.Client.Game.Control;
 using FFXIVClientStructs.FFXIV.Client.System.Framework;
 using FFXIVClientStructs.FFXIV.Client.UI.Agent;
+using GagSpeak.GameInternals.Addons;
 using GagSpeak.GameInternals.Structs;
 using GagSpeak.PlayerControl;
 using GagSpeak.Services;
@@ -45,6 +46,19 @@ public unsafe class MoveOverrides : IDisposable
     public float Proximity = 0.01f;
     public bool _legacyMode;
 
+    // Progress tracking, so a caller can tell 'walking' apart from 'wedged against a wall'.
+    private bool _trackingProgress;
+    private long _lastProgressTick;
+    // Closest we have come to the target so far, to catch traveling confidently the wrong way.
+    private float _closestDistanceXZ;
+    private float _currentDistanceXZ;
+
+    /// <summary> How long we have gone without meaningful displacement, in ms. 0 when not tracking. </summary>
+    public long StalledFor => _trackingProgress ? Environment.TickCount64 - _lastProgressTick : 0;
+
+    /// <summary> How much further from the target we are than our best approach. 0 when not tracking. </summary>
+    public float DivergedBy => _trackingProgress ? _currentDistanceXZ - _closestDistanceXZ : 0f;
+
     public MoveOverrides()
     {
         Svc.Hook.InitializeFromAttributes(this);
@@ -61,6 +75,12 @@ public unsafe class MoveOverrides : IDisposable
 
     private void OnConfigChanged(object? sender, ConfigChangeEvent evt)
         => _legacyMode = Svc.GameConfig.UiControl.TryGetUInt("MoveMode", out var mode) && mode == 1;
+    
+    private delegate byte RMIWalkIsInputEnabledDelegate(void* self);
+    [Signature(Signatures.RMIWalkIsInputEnabled1, Fallibility = Fallibility.Fallible)]
+    private readonly RMIWalkIsInputEnabledDelegate? _rmiWalkIsInputEnabled1 = null;
+    [Signature(Signatures.RMIWalkIsInputEnabled2, Fallibility = Fallibility.Fallible)]
+    private readonly RMIWalkIsInputEnabledDelegate? _rmiWalkIsInputEnabled2 = null;
 
     private delegate void RMIWalkDelegate(void* self, float* sumLeft, float* sumForward, float* sumTurnLeft, byte* haveBackwardOrStrafe, byte* a6, byte bAdditiveUnk);
     [Signature(Signatures.RMIWalk)]
@@ -69,14 +89,49 @@ public unsafe class MoveOverrides : IDisposable
     {
         RMIWalkHook.Original(self, sumLeft, sumForward, sumTurnLeft, haveBackwardOrStrafe, a6, bAdditiveUnk);
 
-        var movementAllowed = bAdditiveUnk == 0 && !Svc.Condition[Dalamud.Game.ClientState.Conditions.ConditionFlag.BeingMoved];
-        if (movementAllowed && *sumLeft == 0 && *sumForward == 0 && DirectionToDestination(false) is var relDir && relDir != null)
-        {
-            var dir = relDir.Value.h.ToDirection();
-            *sumLeft = dir.X;
-            *sumForward = dir.Y;
-        }
+        if (bAdditiveUnk != 0 || !GameWantsWalkInput(self))
+            return;
+
+        if (DirectionToDestination(false) is not { } relDir)
+            return;
+
+        // Upstream only fills in a heading when the player is supplying none of their own, which is
+        // right for a navigation convenience tool but is an escape hatch for forced movement: the
+        // movement-key blocks never see LMB+RMB mouse-running, so it arrives here as player input and
+        // would win. This hook is only live during a forced move task, so overwrite regardless.
+        var dir = relDir.h.ToDirection();
+        *sumLeft = dir.X;
+        *sumForward = dir.Y;
     }
+
+    /// <summary>
+    ///     Mirrors the pair of checks PlayerMoveController::readInput performs. If the signatures
+    ///     could not be resolved, we fall back to the old, weaker condition rather than doing nothing.
+    /// </summary>
+    private bool GameWantsWalkInput(void* self)
+    {
+        if (_rmiWalkIsInputEnabled1 is { } first && _rmiWalkIsInputEnabled2 is { } second)
+            return first(self) != 0 && second(self) != 0;
+
+        return !Svc.Condition[Dalamud.Game.ClientState.Conditions.ConditionFlag.BeingMoved];
+    }
+
+    /// <summary>
+    ///     Offset between the camera's stored DirH and the direction it actually looks. <para />
+    ///     In third person mode DirH is the character-to-camera orbit azimuth, so the look direction sits
+    ///     180 degrees off it. In first person the camera rides the character and DirH already is the
+    ///     look direction. Both verified against observed travel headings.
+    /// </summary>
+    private static Angle CameraLookOffset
+        => AddonCameraManager.ActiveMode is CameraControlMode.FirstPerson ? default : 180.Degrees();
+
+    /// <summary> The direction the camera is actually looking. </summary>
+    private static Angle CameraLookDir(GameCamera* camera)
+        => camera->DirH.Radians() + CameraLookOffset;
+
+    /// <summary> The DirH value that would have the camera looking along <paramref name="look"/>. </summary>
+    private static Angle AzimuthForLook(Angle look)
+        => look - CameraLookOffset;
 
     private (Angle h, Angle v)? DirectionToDestination(bool allowVertical)
     {
@@ -91,8 +146,10 @@ public unsafe class MoveOverrides : IDisposable
         var dirH = Angle.FromDirectionXZ(dist);
         var dirV = allowVertical ? Angle.FromDirection(new(dist.Y, new Vector2(dist.X, dist.Z).Length())) : default;
 
+        // Legacy movement is camera-relative, so it resolves against where the camera looks - which
+        // is not DirH itself in every perspective, hence CameraLookDir.
         var refDir = _legacyMode
-            ? ((GameCamera*)CameraManager.Instance()->GetActiveCamera())->DirH.Radians() + 180.Degrees()
+            ? CameraLookDir((GameCamera*)CameraManager.Instance()->GetActiveCamera())
             : player.Rotation.Radians();
         return (dirH - refDir, dirV);
     }
@@ -118,15 +175,25 @@ public unsafe class MoveOverrides : IDisposable
         OverrideMoveInput = false;
         TargetPos = Vector3.Zero;
         Proximity = 0.01f;
+        // Reset progress tracking too, otherwise the next task starts measuring against a stale position.
+        PrevPos = Vector3.Zero;
+        _trackingProgress = false;
+        _lastProgressTick = 0;
+        _closestDistanceXZ = 0f;
+        _currentDistanceXZ = 0f;
     }
 
     // a version of MoveToNode but for position.
-    // returns true when it has reached the point within the spesified proximity.
+    // returns true when it has reached the point within the specified proximity.
     // recommended to call disable after it returns true.
     public unsafe bool MoveToPoint(Vector3 point, float proximity = 0.01f)
     {
         if (!PlayerData.Available)
+        {
+            // Don't accrue stall time while zoning or otherwise unavailable.
+            _trackingProgress = false;
             return false;
+        }
 
         TargetPos = point;
         Proximity = proximity;
@@ -143,24 +210,69 @@ public unsafe class MoveOverrides : IDisposable
         OverrideMoveInput = true;
         OverrideCamera = true;
         SpeedH = SpeedV = 360.Degrees();
-        DesiredAzimuth = Angle.FromDirectionXZ(TargetPos - PlayerData.Position) + 180.Degrees();
+        DesiredAzimuth = AzimuthForLook(Angle.FromDirectionXZ(TargetPos - PlayerData.Position));
         DesiredAltitude = -30.Degrees();
 
-        // help with stuckage.
-        if (AgentMap.Instance()->IsPlayerMoving)
-        {
-            var minSpeedAllowed = Control.Instance()->IsWalking ? 0.015f : 0.05f;
-            if (HcTaskManager.ElapsedTime > 500 && !PlayerData.IsJumping)
-            {
-                if (PlayerData.DistanceTo(PrevPos) < minSpeedAllowed && NodeThrottler.Throttle("HcTaskFunc.Jump", 1250))
-                {
-                    ChatService.SendGeneralActionCommand(2); // Jumping!
-                    Svc.Logger.Verbose("Jumping to try and get unstuck.");
-                }
-            }
-
-            PrevPos = PlayerData.Position;
-        }
+        TrackProgress(toNext.Length());
         return false;
+    }
+
+    /// <summary>
+    ///     <see cref="MoveToPoint"/>, but returns null once we have made no progress for
+    ///     <paramref name="stallMs"/>, which the task manager treats as a hard failure.
+    /// </summary>
+    public unsafe bool? MoveToPointOrFail(Vector3 point, float proximity, int stallMs, float divergeMargin)
+    {
+        if (MoveToPoint(point, proximity))
+            return true;
+
+        if (stallMs > 0 && StalledFor > stallMs)
+            return null;
+
+        // There is no pathing here, only a straight line, so steadily getting further away is never
+        // legitimate progress - it means we are being driven somewhere we did not ask to go.
+        if (divergeMargin > 0 && DivergedBy > divergeMargin)
+            return null;
+
+        return false;
+    }
+
+    /// <summary>
+    ///     Records whether we actually displaced this frame, and jumps to try shaking loose of
+    ///     whatever we are caught on when we did not.
+    /// </summary>
+    private unsafe void TrackProgress(float distanceXZ)
+    {
+        var now = Environment.TickCount64;
+        var pos = PlayerData.Position;
+        _currentDistanceXZ = distanceXZ;
+
+        if (!_trackingProgress)
+        {
+            _trackingProgress = true;
+            _lastProgressTick = now;
+            _closestDistanceXZ = distanceXZ;
+            PrevPos = pos;
+            return;
+        }
+
+        if (distanceXZ < _closestDistanceXZ)
+            _closestDistanceXZ = distanceXZ;
+
+        var minSpeedAllowed = Control.Instance()->IsWalking ? 0.015f : 0.05f;
+        if (Vector3.Distance(pos, PrevPos) >= minSpeedAllowed)
+            _lastProgressTick = now;
+        // Something is potentially obstructing our movement. If we have slowed to a crawl and have
+        // not jumped recently, try jumping.
+        else if (AgentMap.Instance()->IsPlayerMoving && HcTaskManager.ElapsedTime > 500 && !PlayerData.IsJumping)
+        {
+            if (NodeThrottler.Throttle("HcTaskFunc.Jump", 1250))
+            {
+                ChatService.SendGeneralActionCommand(2); // Jumping!
+                Svc.Logger.Verbose("Jumping to try and get unstuck.");
+            }
+        }
+
+        PrevPos = pos;
     }
 }

--- a/ProjectGagSpeak/PlayerControl/Controllers/ImprisonmentController.cs
+++ b/ProjectGagSpeak/PlayerControl/Controllers/ImprisonmentController.cs
@@ -9,9 +9,12 @@ namespace GagSpeak.Services.Controller;
 public class ImprisonmentController : DisposableMediatorSubscriberBase
 {
     private const string ReturnToCageName = "RETURN_TO_CAGE";
+
+    // Threshold for arriving at the cage. This prevents a inf loop on entering and leaving the cage.
+    private const float ArrivalFactor = 0.75f;
+
     private readonly HcTaskManager _hcTasks;
 
-    private bool _returningToCage => StaticDetours.MoveOverrides.InMoveTask;
     public ImprisonmentController(ILogger<ImprisonmentController> logger, GagspeakMediator mediator,
         HcTaskManager hcTasks) : base(logger, mediator)
     {
@@ -52,7 +55,7 @@ public class ImprisonmentController : DisposableMediatorSubscriberBase
         var currentTerritory = PlayerContent.TerritoryIdInstanced;
         if (hc.ImprisonedTerritory != currentTerritory)
         {
-            _hcTasks.RemoveIfPresent("MoveToPoint");
+            _hcTasks.RemoveIfPresent(ReturnToCageName);
             IsImprisoned = false;
             Logger.LogDebug($"Updated: IsImprisoned={IsImprisoned}, CageTerritoryId={CageTerritoryId}, CageOrigin={CageOrigin}, CageRadius={CageRadius}");
             return;
@@ -65,7 +68,7 @@ public class ImprisonmentController : DisposableMediatorSubscriberBase
             // invalidate if we are too far from current position.
             if (PlayerData.DistanceTo(newPos) > 15)
             {
-                _hcTasks.RemoveIfPresent("MoveToPoint");
+                _hcTasks.RemoveIfPresent(ReturnToCageName);
                 IsImprisoned = false;
                 Logger.LogDebug($"Updated: IsImprisoned={IsImprisoned}, CageTerritoryId={CageTerritoryId}, CageOrigin={CageOrigin}, CageRadius={CageRadius}");
                 return;
@@ -81,25 +84,31 @@ public class ImprisonmentController : DisposableMediatorSubscriberBase
 
     private void FrameworkUpdate()
     {
-        if (!IsImprisoned)
+        if (!IsImprisoned || !PlayerData.Available)
             return;
 
-        // if we are not in a return task, check if we are further from the allowed area.
-        if (!_returningToCage && PlayerData.Available)
-        {
-            // if the distance is larger than the cage radius, begin returning to cage.
-            if (PlayerData.DistanceTo(CageOrigin) > CageRadius)
-                _hcTasks.InsertTask(() => StaticDetours.MoveOverrides.MoveToPoint(CageOrigin, CageRadius), ReturnToCageName, HcTaskConfiguration.Default with { OnEnd = () => StaticDetours.MoveOverrides.Disable(), Flags = State.HcTaskControl.BlockMovementKeys });
-        }
+        // already on our way back, don't stack another task on top of it.
+        if (_hcTasks.HasTask(ReturnToCageName))
+            return;
+        
+        if (PlayerData.DistanceTo(new Vector2(CageOrigin.X, CageOrigin.Z)) <= CageRadius)
+            return;
+
+        // snapshot the cage, so a task outliving FullStopImprisonment can't retarget to the world origin.
+        var origin = CageOrigin;
+        var arrival = CageRadius * ArrivalFactor;
+        _hcTasks.InsertTask(() => StaticDetours.MoveOverrides.MoveToPoint(origin, arrival), ReturnToCageName, HcTaskConfiguration.Default with { OnEnd = () => StaticDetours.MoveOverrides.Disable(), Flags = State.HcTaskControl.BlockMovementKeys });
     }
 
     public void FullStopImprisonment()
     {
+        _hcTasks.RemoveIfPresent(ReturnToCageName);
+        StaticDetours.MoveOverrides.Disable();
+
         ShouldBeImprisoned = false;
         IsImprisoned = false;
         CageTerritoryId = 0;
         CageOrigin = Vector3.Zero;
         CageRadius = 1f;
-        _hcTasks.RemoveIfPresent("MoveToPoint");
     }
 }

--- a/ProjectGagSpeak/PlayerControl/Controllers/ImprisonmentController.cs
+++ b/ProjectGagSpeak/PlayerControl/Controllers/ImprisonmentController.cs
@@ -1,4 +1,5 @@
 using CkCommons;
+using Dalamud.Interface.ImGuiNotification;
 using GagSpeak.GameInternals.Detours;
 using GagSpeak.PlayerClient;
 using GagSpeak.PlayerControl;
@@ -9,11 +10,15 @@ namespace GagSpeak.Services.Controller;
 public class ImprisonmentController : DisposableMediatorSubscriberBase
 {
     private const string ReturnToCageName = "RETURN_TO_CAGE";
-
-    // Threshold for arriving at the cage. This prevents a inf loop on entering and leaving the cage.
     private const float ArrivalFactor = 0.75f;
+    private const int StallTimeoutMs = 5000;
+    private const int RetryCooldownMs = 15000;
+    private const float RetryDistanceMargin = 1f;
+    private const float DivergenceMargin = 3f;
 
     private readonly HcTaskManager _hcTasks;
+    private float? _gaveUpAtDistance;
+    private long _gaveUpAtTick;
 
     public ImprisonmentController(ILogger<ImprisonmentController> logger, GagspeakMediator mediator,
         HcTaskManager hcTasks) : base(logger, mediator)
@@ -29,6 +34,8 @@ public class ImprisonmentController : DisposableMediatorSubscriberBase
     public uint CageTerritoryId { get; private set; } = 0;
     public Vector3 CageOrigin { get; private set; } = Vector3.Zero;
     public float CageRadius { get; private set; } = 1f;
+
+    private Vector2 CageOriginXZ => new(CageOrigin.X, CageOrigin.Z);
 
     private void OnHcCacheStateChange()
     {
@@ -73,9 +80,13 @@ public class ImprisonmentController : DisposableMediatorSubscriberBase
                 Logger.LogDebug($"Updated: IsImprisoned={IsImprisoned}, CageTerritoryId={CageTerritoryId}, CageOrigin={CageOrigin}, CageRadius={CageRadius}");
                 return;
             }
+            // A re-positioned cage is a different problem, so don't hold an earlier give-up against it.
+            if (newPos != CageOrigin || !hc.ImprisonedRadius.Equals(CageRadius))
+                _gaveUpAtDistance = null;
+
             // update our imprisonment data if we have any.
             CageTerritoryId = (uint)hc.ImprisonedTerritory;
-            CageOrigin = ClientData.GetImprisonmentPos();
+            CageOrigin = newPos;
             CageRadius = hc.ImprisonedRadius;
             IsImprisoned = true;
         }
@@ -90,14 +101,60 @@ public class ImprisonmentController : DisposableMediatorSubscriberBase
         // already on our way back, don't stack another task on top of it.
         if (_hcTasks.HasTask(ReturnToCageName))
             return;
-        
-        if (PlayerData.DistanceTo(new Vector2(CageOrigin.X, CageOrigin.Z)) <= CageRadius)
+
+        var distance = PlayerData.DistanceTo(CageOriginXZ);
+        if (distance <= CageRadius)
+        {
+            // Back inside, so any earlier failure is no longer interesting.
+            _gaveUpAtDistance = null;
             return;
+        }
+
+        if (!CanRetryReturn(distance))
+            return;
+
+        _gaveUpAtDistance = null;
 
         // snapshot the cage, so a task outliving FullStopImprisonment can't retarget to the world origin.
         var origin = CageOrigin;
         var arrival = CageRadius * ArrivalFactor;
-        _hcTasks.InsertTask(() => StaticDetours.MoveOverrides.MoveToPoint(origin, arrival), ReturnToCageName, HcTaskConfiguration.Default with { OnEnd = () => StaticDetours.MoveOverrides.Disable(), Flags = State.HcTaskControl.BlockMovementKeys });
+        _hcTasks.InsertTask(() => ReturnToCage(origin, arrival), ReturnToCageName,
+            HcTaskConfiguration.Default with { OnEnd = () => StaticDetours.MoveOverrides.Disable(), Flags = State.HcTaskControl.BlockMovementKeys });
+    }
+
+    /// <summary>
+    ///     Walks back toward the cage. Returns null once we have stopped making progress, which the
+    ///     task manager treats as a failure rather than grinding against a wall until the timeout.
+    /// </summary>
+    private bool? ReturnToCage(Vector3 origin, float arrival)
+    {
+        var result = StaticDetours.MoveOverrides.MoveToPointOrFail(origin, arrival, StallTimeoutMs, DivergenceMargin);
+        if (result is not null)
+            return result;
+
+        // Record where we stopped so we know what counts as 'they moved further out' later on.
+        _gaveUpAtDistance = PlayerData.DistanceTo(CageOriginXZ);
+        _gaveUpAtTick = Environment.TickCount64;
+        Logger.LogWarning($"Could not reach the cage at {origin:F2} (gave up {_gaveUpAtDistance:F1} yalms out, " +
+            $"stalled {StaticDetours.MoveOverrides.StalledFor}ms, diverged {StaticDetours.MoveOverrides.DivergedBy:F1} yalms). " +
+            $"Retrying in {RetryCooldownMs / 1000}s, or sooner if you move further away.");
+        Mediator.Publish(new NotificationMessage("Imprisonment", "Something is blocking the way back to your cage!", NotificationType.Warning));
+        return null;
+    }
+
+    /// <summary>
+    ///     After a failed return we hold off re-trying until either the cooldown elapses or the
+    ///     player has moved meaningfully further out than where the attempt was abandoned.
+    /// </summary>
+    private bool CanRetryReturn(float distance)
+    {
+        if (_gaveUpAtDistance is not { } gaveUpAt)
+            return true;
+
+        if (distance > gaveUpAt + RetryDistanceMargin)
+            return true;
+
+        return Environment.TickCount64 - _gaveUpAtTick >= RetryCooldownMs;
     }
 
     public void FullStopImprisonment()
@@ -110,5 +167,7 @@ public class ImprisonmentController : DisposableMediatorSubscriberBase
         CageTerritoryId = 0;
         CageOrigin = Vector3.Zero;
         CageRadius = 1f;
+        _gaveUpAtDistance = null;
+        _gaveUpAtTick = 0;
     }
 }

--- a/ProjectGagSpeak/PlayerControl/HardcoreTaskManager/HcTaskManager.cs
+++ b/ProjectGagSpeak/PlayerControl/HardcoreTaskManager/HcTaskManager.cs
@@ -65,16 +65,33 @@ public partial class HcTaskManager : IDisposable
         if (taskName.Equals(_taskOperations[0].Name, StringComparison.OrdinalIgnoreCase))
             AbortCurrentTask();
     }
+    public bool HasTask(string taskName)
+        => _taskOperations.Any(t => taskName.Equals(t.Name, StringComparison.OrdinalIgnoreCase));
+
     public void RemoveIfPresent(string taskName)
     {
         if (_taskOperations.Count is 0)
             return;
 
-        // if the task with the same name exists in the queue, remove it.
-        if (_taskOperations[0].Name.Equals(taskName, StringComparison.OrdinalIgnoreCase))
-            AbortCurrentTask();
-        else
-            _taskOperations.RemoveAll(t => taskName.Equals(t.Name, StringComparison.OrdinalIgnoreCase));
+        var removedActive = false;
+        // Walk backwards so a removal never shifts an index we have yet to visit.
+        for (var i = _taskOperations.Count - 1; i >= 0; i--)
+        {
+            var task = _taskOperations[i];
+            if (!taskName.Equals(task.Name, StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            _logger.LogDebug($"Aborting Task: {task.Name}", LoggerType.HardcoreTasks);
+            if (!task.Finished)
+                task.End();
+
+            _taskOperations.RemoveAt(i);
+            removedActive |= i is 0;
+        }
+
+        // Only surrender the control flags if the task holding them is the one that went away.
+        if (removedActive)
+            _cache.SetActiveTaskControl(HcTaskControl.None);
     }
 
     public void AbortTasks()

--- a/ProjectGagSpeak/PlayerControl/Utils/HcStayMain.cs
+++ b/ProjectGagSpeak/PlayerControl/Utils/HcStayMain.cs
@@ -9,6 +9,9 @@ namespace GagSpeak;
 
 public static unsafe class HcApproachNearestHousing
 {
+    // Callers enqueue this collection standalone, so they need the name to remove it again.
+    public const string CollectionName = "Enter Housing";
+
     public static bool IsTargetApartment()
     {
         var tName = Svc.Targets.Target?.Name.ToString() ?? string.Empty;
@@ -20,7 +23,7 @@ public static unsafe class HcApproachNearestHousing
 
     public static HardcoreTaskCollection GetTaskCollection(HcTaskManager hcTasks, int appartmentRoom = int.MaxValue)
     {
-        return hcTasks.CreateCollection("Enter Housing", new(HcTaskControl.LockThirdPerson | HcTaskControl.BlockAllKeys | HcTaskControl.DoConfinementPrompts))
+        return hcTasks.CreateCollection(CollectionName, new(HcTaskControl.LockThirdPerson | HcTaskControl.BlockAllKeys | HcTaskControl.DoConfinementPrompts))
             .Add(new HardcoreTask(GagspeakEx.IsPlayerFullyLoaded))
             .Add(new HardcoreTask(TargetNearestHousingNode))
             .Add(hcTasks.CreateBranch(IsTargetApartment, "Approach Housing Node")

--- a/ProjectGagSpeak/State/Caches/PlayerControlCache.cs
+++ b/ProjectGagSpeak/State/Caches/PlayerControlCache.cs
@@ -140,6 +140,10 @@ public sealed class PlayerControlCache
     // Update the hardcore task manager control state and refresh the controllers with the latest cache information.
     public void SetActiveTaskControl(HcTaskControl control)
     {
+        // Task begin/end calls this every frame a task runs, so only wake the controllers on a real change.
+        if (_activeTaskControl == control)
+            return;
+
         _activeTaskControl = control;
         _mediator.Publish(new HcStateCacheChanged());
     }

--- a/ProjectGagSpeak/State/Handlers/PlayerControlHandler.cs
+++ b/ProjectGagSpeak/State/Handlers/PlayerControlHandler.cs
@@ -29,6 +29,8 @@ public class PlayerCtrlHandler
     private readonly OverlayHandler _overlay;
     private readonly HcTaskManager _hcTasks;
     private readonly KinksterManager _kinksters;
+    
+    private const string ConfinementTaskName = "Travel To Location";
 
     // Stores the players's movement mode, useful for when we change it.
     private MovementMode _cachedPlayerMoveMode = MovementMode.NotSet;
@@ -178,7 +180,7 @@ public class PlayerCtrlHandler
         Svc.Framework.RunOnFrameworkThread(() =>
         {
             // Not respecting inner timeouts for some reason
-            _hcTasks.CreateCollection("Travel To Location", HcTaskConfiguration.Branch with {  Flags = taskCtrlFlags })
+            _hcTasks.CreateCollection(ConfinementTaskName, HcTaskConfiguration.Branch with {  Flags = taskCtrlFlags })
                 .Add(_hcTasks.CreateBranch(() => doLifestreamMethod, "LifestreamTravelTask", HcTaskConfiguration.Branch)
                     .SetTrueTask(_hcTasks.CreateGroup("TravelTaskGroup", HcTaskConfiguration.Default with { TimeoutAt = 120000 })
                         .Add(GagspeakEx.IsPlayerFullyLoaded)
@@ -206,7 +208,8 @@ public class PlayerCtrlHandler
     {
         _logger.LogInformation($"[{enactor.AliasOrUID}] Disabled your Indoor Confinement state!", LoggerType.HardcoreMovement);
 
-        _hcTasks.RemoveIfPresent("Travel To Confinement");
+        _hcTasks.RemoveIfPresent(ConfinementTaskName);
+        _hcTasks.RemoveIfPresent(HcApproachNearestHousing.CollectionName);
         _mediator.Publish(new HcStateCacheChanged());
 
         if (giveAchievements)

--- a/ProjectGagSpeak/UI/MainUi/SidePanel/SidePanelKinkster/SidePanelPair.Hardcore.cs
+++ b/ProjectGagSpeak/UI/MainUi/SidePanel/SidePanelKinkster/SidePanelPair.Hardcore.cs
@@ -87,7 +87,9 @@ public partial class SidePanelPair
             CkGui.AttachTooltip($"Set the radius {dispName} can move within their cage. Be careful of pathing!");
 
             ImUtf8.SameLineInner();
-            var clientInAnchorRange = PlayerData.DistanceTo(cache.ImprisonPos) <= cache.ImprisonRadius;
+            // XZ-only, to match the rule ImprisonmentController actually enforces on the cage.
+            var anchorXZ = new Vector2(cache.ImprisonPos.X, cache.ImprisonPos.Z);
+            var clientInAnchorRange = PlayerData.DistanceTo(anchorXZ) <= cache.ImprisonRadius;
             var frameCol = clientInAnchorRange ? CkCol.TriStateCheck.Vec4().ToUint() : CkCol.TriStateCross.Vec4().ToUint();
             using (CkRaii.FramedChild("CageAnchor", new Vector2(rightW, ImGui.GetFrameHeight()), 0, frameCol, CkStyle.ListItemRounding(), CkStyle.ThinThickness()))
                 CkGui.CenterTextAligned($"{cache.ImprisonPos:F1}");


### PR DESCRIPTION
The RETURN_TO_CAGE task was repeatedly being re-queued and could force the player to world origin because imprisonment used a 3D escape check while MoveToPoint used an XZ check, causing tasks started while already inside the cage to finish their frame and be re-inserted every frame.