### PR TITLE
Restore Mimic Trait Tooltip lost from conflict

### DIFF
--- a/ProjectGagSpeak/Localization/Strings.cs
+++ b/ProjectGagSpeak/Localization/Strings.cs
@@ -1179,7 +1179,7 @@ namespace GagSpeak.Localization
 
         public readonly string MimicsApplyTraits = Loc.Localize("MainOptions_MimicsApplyTraits", "Cursed Loot can Apply Traits");
         public readonly string MimicsApplyTraitsTT = Loc.Localize("MainOptions_MimicsApplyTraitsTT", "Allows applied cursed items to set their hardcore traits." +
-            "--SEP--WARNING: This includes traits such as immobilize, weighted, and other action limiting factors!");
+            "--SEP--WARNING: This includes limiting traits (immobilize and weighted excluded)!");
         
         public readonly string MimicsApplyOverlays = Loc.Localize("MainOptions_MimicsApplyOverlays", "Cursed Loot can Apply Overlays");
         public readonly string MimicsApplyOverlaysTT = Loc.Localize("MainOptions_MimicsApplyOverlaysTT", "Allows applied cursed items to set overlays." +


### PR DESCRIPTION
restored tooltip string that was lost when resolving conflicts with another PR.