### PR TITLE
Bug/fix glamour reapply loop causing weapon flashing

### DIFF
--- a/ProjectGagSpeak/Interop/Ipc/IpcCallerGlamourer.cs
+++ b/ProjectGagSpeak/Interop/Ipc/IpcCallerGlamourer.cs
@@ -92,6 +92,7 @@ public sealed class IpcCallerGlamourer : DisposableMediatorSubscriberBase, IIpcC
             return;
         try
         {
+            _logger.LogTrace($"Setting Glamourer Item Slot {slot} to ItemID {item}.", LoggerType.IpcGlamourer);
             await Svc.Framework.RunOnFrameworkThread(() => SetItem.Invoke(0, slot, item, dye, GAGSPEAK_LOCK)).ConfigureAwait(false);
         }
         catch (Exception ex)
@@ -110,6 +111,7 @@ public sealed class IpcCallerGlamourer : DisposableMediatorSubscriberBase, IIpcC
 
         try
         {
+            _logger.LogTrace($"Setting Glamourer MetaState {metaTypes} to {newValue}.", LoggerType.IpcGlamourer);
             await Svc.Framework.RunOnFrameworkThread(() => SetMetaState.Invoke(0, metaTypes, newValue, GAGSPEAK_LOCK)).ConfigureAwait(false);
         }
         catch (Exception ex)

--- a/ProjectGagSpeak/State/Caches/GlamourActorState.cs
+++ b/ProjectGagSpeak/State/Caches/GlamourActorState.cs
@@ -43,6 +43,38 @@ public struct GlamourActorState
     }
 
     /// <summary>
+    ///   Reads a single equipment slot out of a raw Glamourer state object.
+    /// </summary>
+    /// <remarks> Lets us compare against Glamourer's live state without parsing the whole object. </remarks>
+    public static bool TryReadSlot(JObject? state, EquipSlot slot, out ulong customItemId, out byte stain, out byte stain2)
+    {
+        customItemId = ulong.MaxValue;
+        stain = 0;
+        stain2 = 0;
+
+        if (state?["Equipment"] is not JToken equipment || !EquipSlotExtensions.EqdpSlots.Contains(slot))
+            return false;
+
+        customItemId = equipment[slot.ToString()]?["ItemId"]?.Value<ulong>() ?? 4294967164;
+        stain = equipment[slot.ToString()]?["Stain"]?.Value<byte>() ?? 0;
+        stain2 = equipment[slot.ToString()]?["Stain2"]?.Value<byte>() ?? 0;
+        return true;
+    }
+
+    /// <summary>
+    ///   Reads the Hat/Visor/Weapon metadata out of a raw Glamourer state object.
+    /// </summary>
+    public static bool TryReadMeta(JObject? state, out MetaDataStruct meta)
+    {
+        meta = MetaDataStruct.Empty;
+        if (state?["Equipment"] is not JToken equipment)
+            return false;
+
+        meta = ReadMeta(equipment);
+        return true;
+    }
+
+    /// <summary>
     ///   Attempts to update the active Glamour Actors state with its most recent data. <para />
     ///   Current bound state is passed in so that we can run a comparison against the slots. <para />
     ///   However, do not pass in the FinalMeta, as we should cache the latest metadata state in accordance to base game.
@@ -92,7 +124,7 @@ public struct GlamourActorState
     }
 
     /// <summary> Only updates metadata when no flags for a particular metastate are occupied by bound items. </summary>
-    public void UpdateMetaCheckBinds(JObject newState, MetaDataStruct finalMeta, bool anyHat, bool anyVisor, bool anyWep)
+    public void UpdateMetaCheckBinds(JObject newState, bool anyHat, bool anyVisor, bool anyWep)
     {
         // Update object entirely if it was null before.
         if (State is null)
@@ -101,29 +133,15 @@ public struct GlamourActorState
         if (newState?["Equipment"] is not JToken equipment)
             return;
 
-        // parse the metadata.
-        var sh = newState["Equipment"]?["Hat"]?["Show"]?.Value<bool>() ?? false;
-        var ah = newState["Equipment"]?["Hat"]?["Apply"]?.Value<bool>() ?? false;
-        var sv = newState["Equipment"]?["Visor"]?["IsToggled"]?.Value<bool>() ?? false;
-        var av = newState["Equipment"]?["Visor"]?["Apply"]?.Value<bool>() ?? false;
-        var sw = newState["Equipment"]?["Weapon"]?["Show"]?.Value<bool>() ?? false;
-        var aw = newState["Equipment"]?["Weapon"]?["Apply"]?.Value<bool>() ?? false;
-        //Svc.Logger.Verbose($"[GlamourActorState] Updating Meta: Hat({sh}, {ah}), Visor({sv}, {av}), Weapon({sw}, {aw})");
-        // set the metadata based on the retrieved values.
-        var hatState = (sh, ah) switch { (true, true) => TriStateBool.True, (false, true) => TriStateBool.False, _ => TriStateBool.Null };
-        // If no hatstates are stored, just apply whatever was passed in.
+        // Only refresh a metastate that no bound item is currently occupying, otherwise
+        // we would cache our own enforced value as the base to restore back to later.
+        var latest = ReadMeta(equipment);
         if (!anyHat)
-            MetaStates = MetaStates.WithMetaIfDifferent(MetaIndex.HatState, hatState);
-        
-        var visorState = (sv, av) switch { (true, true) => TriStateBool.True, (false, true) => TriStateBool.False, _ => TriStateBool.Null };
-        // If no visor states are stored, just apply whatever was passed in.
+            MetaStates = MetaStates.WithMetaIfDifferent(MetaIndex.HatState, latest.Headgear);
         if (!anyVisor)
-            MetaStates = MetaStates.WithMetaIfDifferent(MetaIndex.VisorState, visorState);
-       
-        // If no weapon states are stored, just apply whatever was passed in.
-        var weaponState = (sw, aw) switch { (true, true) => TriStateBool.True, (false, true) => TriStateBool.False, _ => TriStateBool.Null };
+            MetaStates = MetaStates.WithMetaIfDifferent(MetaIndex.VisorState, latest.Visor);
         if (!anyWep)
-            MetaStates = MetaStates.WithMetaIfDifferent(MetaIndex.WeaponState, weaponState);
+            MetaStates = MetaStates.WithMetaIfDifferent(MetaIndex.WeaponState, latest.Weapon);
     }
 
     /// <summary> Forcibly updates all metastates to the latest JObject state. </summary>
@@ -155,36 +173,28 @@ public struct GlamourActorState
         if (equipmentToken is not JObject equipmentObj)
             return;
 
-        // parse the metadata.
-        var sh = equipmentObj?["Hat"]?["Show"]?.Value<bool>() ?? false;
-        var ah = equipmentObj?["Hat"]?["Apply"]?.Value<bool>() ?? false;
-        var sv = equipmentObj?["Visor"]?["IsToggled"]?.Value<bool>() ?? false;
-        var av = equipmentObj?["Visor"]?["Apply"]?.Value<bool>() ?? false;
-        var sw = equipmentObj?["Weapon"]?["Show"]?.Value<bool>() ?? false;
-        var aw = equipmentObj?["Weapon"]?["Apply"]?.Value<bool>() ?? false;
-        // set the metadata based on the retrieved values.
-        var hatState = (sh, ah) switch { (true, true) => TriStateBool.True, (false, true) => TriStateBool.False, _ => TriStateBool.Null };
-        MetaStates = MetaStates.WithMetaIfDifferent(MetaIndex.HatState, hatState);
-        var visorState = (sv, av) switch { (true, true) => TriStateBool.True, (false, true) => TriStateBool.False, _ => TriStateBool.Null };
-        MetaStates = MetaStates.WithMetaIfDifferent(MetaIndex.VisorState, visorState);
-        var weaponState = (sw, aw) switch { (true, true) => TriStateBool.True, (false, true) => TriStateBool.False, _ => TriStateBool.Null };
-        MetaStates = MetaStates.WithMetaIfDifferent(MetaIndex.WeaponState, weaponState);
+        var latest = ReadMeta(equipmentObj);
+        MetaStates = MetaStates
+            .WithMetaIfDifferent(MetaIndex.HatState, latest.Headgear)
+            .WithMetaIfDifferent(MetaIndex.VisorState, latest.Visor)
+            .WithMetaIfDifferent(MetaIndex.WeaponState, latest.Weapon);
     }
+
+    /// <summary> Maps Glamourer's (shown, applied) pairs onto our TriStateBool metadata. </summary>
+    /// <remarks> A state Glamourer is not applying is <see cref="TriStateBool.Null"/>, meaning 'untouched'. </remarks>
+    private static MetaDataStruct ReadMeta(JToken equipment)
+        => new(ToTriState(equipment["Hat"]?["Show"], equipment["Hat"]?["Apply"]),
+               ToTriState(equipment["Visor"]?["IsToggled"], equipment["Visor"]?["Apply"]),
+               ToTriState(equipment["Weapon"]?["Show"], equipment["Weapon"]?["Apply"]));
+
+    private static TriStateBool ToTriState(JToken? shown, JToken? applied)
+        => (shown?.Value<bool>() ?? false, applied?.Value<bool>() ?? false) switch
+        {
+            (true, true) => TriStateBool.True,
+            (false, true) => TriStateBool.False,
+            _ => TriStateBool.Null,
+        };
 
     public bool RecoverSlot(EquipSlot slot, out ulong customItemId, out byte stain, out byte stain2)
-    {
-        if (Equipment is null || !EquipSlotExtensions.EqdpSlots.Contains(slot))
-        {
-            customItemId = ulong.MaxValue;
-            stain = 0;
-            stain2 = 0;
-            return false;
-        }
-        // Return the proper values for the slot.
-        customItemId = Equipment?[slot.ToString()]?["ItemId"]?.Value<ulong>() ?? 4294967164;
-        stain = Equipment?[slot.ToString()]?["Stain"]?.Value<byte>() ?? 0;
-        stain2 = Equipment?[slot.ToString()]?["Stain2"]?.Value<byte>() ?? 0;
-
-        return true;
-    }
+        => TryReadSlot(State, slot, out customItemId, out stain, out stain2);
 }

--- a/ProjectGagSpeak/State/Caches/GlamourCache.cs
+++ b/ProjectGagSpeak/State/Caches/GlamourCache.cs
@@ -6,6 +6,7 @@ using Dalamud.Interface.Utility.Raii;
 using GagSpeak.Services.Textures;
 using GagSpeak.State.Models;
 using GagSpeak.Utils;
+using Glamourer.Api.Enums;
 using OtterGui;
 using Penumbra.GameData.Enums;
 using Penumbra.GameData.Structs;
@@ -183,10 +184,12 @@ public class GlamourCache
             _metaStates[metaIdx] = new SortedList<CombinedCacheKey, TriStateBool>();
     }
 
-    public bool UpdateFinalGlamourCache(out List<EquipSlot> removedSlots)
+    /// <param name="changedSlots"> Slots whose forced item changed, so callers know what must be pushed regardless of live state. </param>
+    public bool UpdateFinalGlamourCache(out List<EquipSlot> removedSlots, out HashSet<EquipSlot> changedSlots)
     {
         var anyChanges = false;
         var seenSlots = new HashSet<EquipSlot>();
+        changedSlots = new HashSet<EquipSlot>();
 
         // Cycle through the glamours in the order they are sorted in.
         foreach (var glamItem in _glamours.Values)
@@ -200,6 +203,7 @@ public class GlamourCache
             {
                 _logger.LogTrace($"Final Slot was: {curr?.GameItem.Name} and will now be {glamItem.GameItem.Name} for slot {glamItem.Slot}");
                 _finalGlamour[glamItem.Slot] = glamItem;
+                changedSlots.Add(glamItem.Slot);
                 anyChanges |= true;
             }
         }
@@ -215,8 +219,10 @@ public class GlamourCache
         return anyChanges || removedSlots.Any();
     }
 
-    public bool UpdateFinalMetaCache(out bool noHat, out bool noVisor, out bool noWeapon)
+    /// <param name="changedFlags"> MetaStates whose forced value changed, so callers know what must be pushed regardless of live state. </param>
+    public bool UpdateFinalMetaCache(out bool noHat, out bool noVisor, out bool noWeapon, out MetaFlag changedFlags)
     {
+        changedFlags = 0;
         var firstHat = GetFirstHatState();
         var firstVisor = GetFirstVisorState();
         var firstWeapon = GetFirstWeaponState();
@@ -229,18 +235,21 @@ public class GlamourCache
         {
             anyChanges |= true;
             _logger.LogDebug($"Updating Final Meta Cache: Hat({firstHat})");
+            changedFlags |= MetaFlag.HatState;
             _finalMeta = _finalMeta.WithMeta(MetaIndex.HatState, firstHat);
         }
         if (_finalMeta.IsDifferent(MetaIndex.VisorState, firstVisor))
         {
             anyChanges |= true;
             _logger.LogDebug($"Updating Final Meta Cache: Visor({firstVisor})");
+            changedFlags |= MetaFlag.VisorState;
             _finalMeta = _finalMeta.WithMeta(MetaIndex.VisorState, firstVisor);
         }
         if (_finalMeta.IsDifferent(MetaIndex.WeaponState, firstWeapon))
         {
             anyChanges |= true;
             _logger.LogDebug($"Updating Final Meta Cache: Weapon({firstWeapon})");
+            changedFlags |= MetaFlag.WeaponState;
             _finalMeta = _finalMeta.WithMeta(MetaIndex.WeaponState, firstWeapon);
         }
         return anyChanges;

--- a/ProjectGagSpeak/State/Handlers/GlamourHandler.cs
+++ b/ProjectGagSpeak/State/Handlers/GlamourHandler.cs
@@ -114,10 +114,12 @@ public class GlamourHandler
         _logger.LogDebug("Updating Glamourer Caches.");
         await ExecuteWithSemaphore(async () =>
         {
+            // Cached once up front, so neither calls write the unbound state.
+            var live = CacheActorState(false);
             // Run both operations in parallel.
             await Task.WhenAll(
-                UpdateMetaInternal(false, true),
-                UpdateGlamourInternal(false, true)
+                UpdateMetaInternal(live, true),
+                UpdateGlamourInternal(live, true)
             );
             _logger.LogInformation($"Processed Cache Updates Successfully!");
         });
@@ -126,17 +128,17 @@ public class GlamourHandler
 
 
     /// <summary> Use this after any glamour Finalization type occurs. </summary>
-    /// <param name="storeProfile"> If true, will force the cache to be applied before updating. </param>
     /// <remarks> This runs through a SemaphoreSlim execution and is handled safely. </remarks>
     public async Task ReapplyAllCaches()
     {
         _logger.LogDebug("Reapplying Glamourer Caches.");
         await ExecuteWithSemaphore(async () =>
         {
+            var live = CacheActorState(true);
             // Run both operations in parallel.
             await Task.WhenAll(
-                ApplyGlamourCache(true),
-                ApplyMetaCache(true)
+                ApplyGlamourCache(live),
+                ApplyMetaCache(live)
             );
             _logger.LogInformation($"Reapplied Cache Updates Successfully!");
         });
@@ -145,32 +147,32 @@ public class GlamourHandler
     /// <summary> Should only ever be used by the GlamourListener. </summary>
     /// <remarks> Handled safely through a SemaphoreSlim. </remarks>
     public async Task UpdateGlamourCacheSlim(bool reapply)
-        => await ExecuteWithSemaphore(() => UpdateGlamourInternal(false, reapply));
+        => await ExecuteWithSemaphore(() => UpdateGlamourInternal(CacheActorState(false), reapply));
 
     /// <summary> Should only ever be used by the GlamourListener. </summary>
     /// <remarks> Handled safely through a SemaphoreSlim. </remarks>
     public async Task UpdateMetaCacheSlim(bool reapply)
-        => await ExecuteWithSemaphore(() => UpdateMetaInternal(true, reapply));
+        => await ExecuteWithSemaphore(() => UpdateMetaInternal(CacheActorState(true), reapply));
 
     /// <summary>
     ///   Updates the Final Glamour Cache, and then applies the visual updates.
     /// </summary>
-    private async Task UpdateGlamourInternal(bool forceCacheCall, bool reapply)
+    private async Task UpdateGlamourInternal(JObject? live, bool reapply)
     {
         // Update the final cache. `removedSlots` contains slots that are no longer restricted after the change.
-        if (_cache.UpdateFinalGlamourCache(out var removedSlots))
+        if (_cache.UpdateFinalGlamourCache(out var removedSlots, out var changedSlots))
         {
             _logger.LogDebug($"Final Glamour Cache was updated!", LoggerType.VisualCache);
             if (removedSlots.Any())
-                await RestoreAndReapply(forceCacheCall, removedSlots);
+                await RestoreAndReapply(live, removedSlots, changedSlots);
             else
-                await ApplyGlamourCache(forceCacheCall);
+                await ApplyGlamourCache(live, changedSlots);
             return;
         }
         else if (reapply)
         {
             _logger.LogDebug("Reapplying Glamour Cache", LoggerType.VisualCache);
-            await ApplyGlamourCache(forceCacheCall);
+            await ApplyGlamourCache(live, changedSlots);
             return;
         }
         // No Change
@@ -180,22 +182,27 @@ public class GlamourHandler
     /// <summary>
     ///   Updates the Final Meta Cache, and then applies the visual updates.
     /// </summary>
-    private async Task UpdateMetaInternal(bool forceCacheCall, bool reapply)
+    private async Task UpdateMetaInternal(JObject? live, bool reapply)
     {
-        // Update the final cache. `removedSlots` contains slots that are no longer restricted after the change.
-        if (_cache.UpdateFinalMetaCache(out bool noHat, out bool noVisor, out bool noWeapon))
+        // What we were enforcing before the update, so we only apply states we are enforcing.
+        var wasForcing = _cache.FinalMeta;
+        // Update the final cache. `noHat`/`noVisor`/`noWeapon` mean nothing binds that state anymore.
+        if (_cache.UpdateFinalMetaCache(out var noHat, out var noVisor, out var noWeapon, out var changedFlags))
         {
             _logger.LogDebug($"Final MetaState Cache was updated!", LoggerType.VisualCache);
-            if (noHat || noVisor || noWeapon)
-                await RestoreMetaAndReapply(forceCacheCall, noHat, noVisor, noWeapon);
+            var releasedHat = noHat && wasForcing.Headgear.HasValue;
+            var releasedVisor = noVisor && wasForcing.Visor.HasValue;
+            var releasedWeapon = noWeapon && wasForcing.Weapon.HasValue;
+            if (releasedHat || releasedVisor || releasedWeapon)
+                await RestoreMetaAndReapply(live, releasedHat, releasedVisor, releasedWeapon, changedFlags);
             else
-                await ApplyMetaCache(forceCacheCall);
+                await ApplyMetaCache(live, changedFlags);
             return;
         }
         else if (reapply)
         {
             _logger.LogDebug("Reapplying MetaState Cache", LoggerType.VisualCache);
-            await ApplyMetaCache(forceCacheCall);
+            await ApplyMetaCache(live, changedFlags);
             return;
         }
         // No Change
@@ -205,35 +212,37 @@ public class GlamourHandler
     /// <summary> 
     ///   Restore slots no longer present in _finalGlamour from <see cref="_cache"/>, then reapplies what is still active.
     /// </summary>
-    private async Task RestoreAndReapply(bool forceCacheCall, IEnumerable<EquipSlot> slotsToRestore)
+    private async Task RestoreAndReapply(JObject? live, IEnumerable<EquipSlot> slotsToRestore, IReadOnlySet<EquipSlot> changedSlots)
     {
         await Task.WhenAll(slotsToRestore
             .Select(slot =>
             {
-                if (_cache.LastUnboundState.RecoverSlot(slot, out var itemId, out var stain, out var stain2))
-                    return _ipc.SetClientItemSlot((ApiEquipSlot)slot, itemId, [stain, stain2], 0);
-                else
+                if (!_cache.LastUnboundState.RecoverSlot(slot, out var itemId, out var stain, out var stain2))
                 {
                     _logger.LogWarning($"Failed to restore slot {slot}, no data found in Glamourer cache.", LoggerType.IpcGlamourer);
                     return Task.CompletedTask;
                 }
+                // if already showing the unbound value, no need to set it again.
+                if (SlotMatchesLive(live, slot, itemId, stain, stain2))
+                    return Task.CompletedTask;
+
+                return _ipc.SetClientItemSlot((ApiEquipSlot)slot, itemId, [stain, stain2], 0);
             }));
         _logger.LogDebug($"Restored Glamourer Slots to last applied base value.", LoggerType.IpcGlamourer);
         // Now reapply the cache.
         _logger.LogDebug("Reapplying Glamourer Cache", LoggerType.IpcGlamourer);
-        await ApplyGlamourCache(forceCacheCall);
+        await ApplyGlamourCache(live, changedSlots);
     }
 
     /// <summary> 
     ///   Apples the FinalGlamour from <see cref="_cache"/> to the Client. 
     /// </summary>
-    private async Task ApplyGlamourCache(bool cacheBeforeApply)
+    /// <remarks> Only differences are set. </remarks>
+    private async Task ApplyGlamourCache(JObject? live, IReadOnlySet<EquipSlot>? changedSlots = null)
     {
-        if (cacheBeforeApply || ActorCacheIsEmpty)
-            CacheActorEquip();
-
         // configure the tasks to run asynchronously.
         await Task.WhenAll(_cache.FinalGlamour
+            .Where(slot => (changedSlots?.Contains(slot.Key) ?? false) || !SlotMatchesLive(live, slot.Key, slot.Value))
             .Select(slot =>
             {
                 var equipSlot = (ApiEquipSlot)slot.Key;
@@ -247,59 +256,100 @@ public class GlamourHandler
         _logger.LogTrace("Applied Active Slots to Glamour", LoggerType.IpcGlamourer);
     }
 
-    private async Task RestoreMetaAndReapply(bool forceCacheCall, bool restoreHat, bool restoreVisor, bool restoreWeapon)
+    /// <summary> Restores the metastates we were forcing back to their last unbound value. </summary>
+    private async Task RestoreMetaAndReapply(JObject? live, bool restoreHat, bool restoreVisor, bool restoreWeapon, MetaFlag changedFlags)
     {
+        GlamourActorState.TryReadMeta(live, out var liveMeta);
+        var unbound = _cache.LastUnboundState.MetaStates;
+
         // If we are restoring the hat, visor or weapon, we need to restore the slots.
-        if (restoreHat && (bool?)_cache.LastUnboundState.MetaStates.Headgear is { } newVal)
+        if (restoreHat && (bool?)unbound.Headgear is { } newVal && !liveMeta.Headgear.Equals(unbound.Headgear))
             await _ipc.SetMetaStates(MetaFlag.HatState, newVal);
-        if (restoreVisor && (bool?)_cache.LastUnboundState.MetaStates.Visor is { } newVal2)
+        if (restoreVisor && (bool?)unbound.Visor is { } newVal2 && !liveMeta.Visor.Equals(unbound.Visor))
             await _ipc.SetMetaStates(MetaFlag.VisorState, newVal2);
-        if (restoreWeapon && (bool?)_cache.LastUnboundState.MetaStates.Weapon is { } newVal3)
+        if (restoreWeapon && (bool?)unbound.Weapon is { } newVal3 && !liveMeta.Weapon.Equals(unbound.Weapon))
             await _ipc.SetMetaStates(MetaFlag.WeaponState, newVal3);
 
         _logger.LogDebug($"Restored Meta Slots to last applied base value.", LoggerType.IpcGlamourer);
 
         // Now reapply the states
         _logger.LogDebug("Reapplying Meta Cache", LoggerType.IpcGlamourer);
-        await ApplyMetaCache(forceCacheCall);
+        await ApplyMetaCache(live, changedFlags);
     }
 
     /// <summary>
     ///   Apples the _finalMeta from the <see cref="_cache"/> Cache to the Client.
     /// </summary>
-    private async Task ApplyMetaCache(bool cacheBeforeApply)
+    /// <remarks> Only differences are pushed. </remarks>
+    private async Task ApplyMetaCache(JObject? live, MetaFlag changedFlags = 0)
     {
-        if (cacheBeforeApply || ActorCacheIsEmpty)
-            CacheActorMeta(false);
+        var final = _cache.FinalMeta;
+        // Without a live state to compare against we cannot tell what is already correct, so push everything.
+        var toWrite = GlamourActorState.TryReadMeta(live, out var liveMeta)
+            ? changedFlags | StaleFlags(final, liveMeta)
+            : changedFlags | final.OnFlags() | final.OffFlags();
 
-        await _ipc.SetMetaStates(_cache.FinalMeta.OnFlags(), true);
-        await _ipc.SetMetaStates(_cache.FinalMeta.OffFlags(), false);
-        // attempt to work around glamourer's wonky issue where it fails to sync meta state updates with visor.
-        // this will result in the visor 'flashing' if out of sync, but the headgear will stay in sync at least.
-        if (_cache.FinalMeta.Visor.Value is true)
+        var writeOn = final.OnFlags() & toWrite;
+        var writeOff = final.OffFlags() & toWrite;
+
+        if (writeOn is not 0)
+            await _ipc.SetMetaStates(writeOn, true);
+        if (writeOff is not 0)
+            await _ipc.SetMetaStates(writeOff, false);
+        
+        // re-assert headgear, Glamourer drops it out of sync when the visor toggles
+        if (((writeOn | writeOff) & MetaFlag.VisorState) is not 0 && final.Headgear.Value is { } hatVal)
         {
             await Task.Delay(1);
-            await _ipc.SetMetaStates(MetaFlag.HatState, true);
+            await _ipc.SetMetaStates(MetaFlag.HatState, hatVal);
         }
-        //_logger.LogDebug("Updated Meta States", LoggerType.IpcGlamourer);
     }
 
-    public void CacheActorEquip()
+    /// <summary> The MetaStates we are enforcing that Glamourer is not currently holding. </summary>
+    private static MetaFlag StaleFlags(MetaDataStruct final, MetaDataStruct live)
     {
-        _logger.LogTrace("Caching latest Equip from Glamourer IPC.", LoggerType.IpcGlamourer);
-        var latestState = _ipc.GetActorState();
-        if (latestState != null)
-        {
-            // create a clone of our latest unbound state to avoid modifying the original.
-            var latestUnboundCopy = GlamourActorState.Clone(_cache.LastUnboundState);
-            latestUnboundCopy.UpdateEquipment(latestState, _cache.FinalGlamour.ToDictionary(x => x.Key, x => x.Value.GameItem));
-            _cache.CacheUnboundState(latestUnboundCopy);
-        }
-        else
+        MetaFlag flags = 0;
+        if (final.Headgear.HasValue && !final.Headgear.Equals(live.Headgear)) flags |= MetaFlag.HatState;
+        if (final.Visor.HasValue && !final.Visor.Equals(live.Visor)) flags |= MetaFlag.VisorState;
+        if (final.Weapon.HasValue && !final.Weapon.Equals(live.Weapon)) flags |= MetaFlag.WeaponState;
+        return flags;
+    }
+
+    /// <summary> True when Glamourer is already showing <paramref name="slot"/> at the given appearance. </summary>
+    private static bool SlotMatchesLive(JObject? live, EquipSlot slot, ulong itemId, byte stain, byte stain2)
+        => live is not null
+        && GlamourActorState.TryReadSlot(live, slot, out var liveItem, out var liveStain, out var liveStain2)
+        && liveItem == itemId && liveStain == stain && liveStain2 == stain2;
+
+    private static bool SlotMatchesLive(JObject? live, EquipSlot slot, GlamourSlot desired)
+        => SlotMatchesLive(live, slot, desired.GameItem.Id.Id, desired.GameStain.Stain1.Id, desired.GameStain.Stain2.Id);
+
+    /// <summary>
+    ///   Caches the actor once for the whole pass, and hands back the state it read. <para />
+    ///   When <paramref name="storeAsUnbound"/> (or we have nothing cached yet) it also refreshes the
+    ///   unbound state that released slots restore back to.
+    /// </summary>
+    /// <returns> Glamourer's live state, so applies can skip values it already holds. </returns>
+    private JObject? CacheActorState(bool storeAsUnbound)
+    {
+        var latest = _ipc.GetActorState();
+        if (!storeAsUnbound && !ActorCacheIsEmpty)
+            return latest;
+
+        if (latest is null)
         {
             _logger.LogDebug("Failed to cache Glamourer state, latest state was null.", LoggerType.IpcGlamourer);
-            _cache.CacheUnboundState(new GlamourActorState(latestState));
+            _cache.CacheUnboundState(new GlamourActorState(null));
+            return null;
         }
+
+        _logger.LogTrace("Caching latest state from Glamourer IPC.", LoggerType.IpcGlamourer);
+        // create a clone of our latest unbound state to avoid modifying the original.
+        var latestUnboundCopy = GlamourActorState.Clone(_cache.LastUnboundState);
+        latestUnboundCopy.UpdateEquipment(latest, _cache.FinalGlamour.ToDictionary(x => x.Key, x => x.Value.GameItem));
+        latestUnboundCopy.UpdateMetaCheckBinds(latest, _cache.AnyHatMeta, _cache.AnyVisorMeta, _cache.AnyWeaponMeta);
+        _cache.CacheUnboundState(latestUnboundCopy);
+        return latest;
     }
 
     /// <summary>
@@ -321,7 +371,7 @@ public class GlamourHandler
             if (flagFromLatest)
                 latestUnboundCopy.UpdateMetaWithLatest(latestState);
             else
-                latestUnboundCopy.UpdateMetaCheckBinds(latestState, _cache.FinalMeta, _cache.AnyHatMeta, _cache.AnyVisorMeta, _cache.AnyWeaponMeta);
+                latestUnboundCopy.UpdateMetaCheckBinds(latestState, _cache.AnyHatMeta, _cache.AnyVisorMeta, _cache.AnyWeaponMeta);
             // finalize the state.
             _cache.CacheUnboundState(latestUnboundCopy);
         }
@@ -331,6 +381,7 @@ public class GlamourHandler
             _cache.CacheUnboundState(new GlamourActorState(latestState));
         }
     }
+
     public void CacheActorFromLatest()
     {
         _logger.LogTrace("Caching Actor from Latest State from Glamourer IPC.", LoggerType.IpcGlamourer);


### PR DESCRIPTION
This prevents the plugin from attempting to apply data to slots that aren't actually owned by the plugin.

ProjectGagSpeak/State/Caches/GlamourActorState.cs
-  removed the duplicated state read from functions. These were turned into two functions that allow you to now read the data of the requested slot.

ProjectGagSpeak/State/Caches/GlamourCache.cs 
- updated to have UpdateFinalGlamourCache and UpdateFinalMetaCache return the data/slots that it actually changed.

ProjectGagSpeak/State/Handlers/GlamourHandler.cs 
- Skips any slot that isn't being forced by a restriction or restraint
- Cache the player state once instead of potentially twice
- now actually checks to see if the glamour slot is applied before attempting to set it.
  - if it's already applied just leave it as is