### PR TITLE
Hardcore escape followups

### DIFF
--- a/ProjectGagSpeak/Services/HardcoreEscapeService.cs
+++ b/ProjectGagSpeak/Services/HardcoreEscapeService.cs
@@ -80,7 +80,7 @@ public class HardcoreEscapeService : DisposableMediatorSubscriberBase
         var pityCount = Math.Min(_pityCounter, MAX_PITY);
         // 0.9^0 = 1 => no change
         // 0.9^10 ~= 0.34 => ~66% easier to escape at the end
-        difficultyOneIn = (int)Math.Ceiling(difficultyOneIn * Math.Pow(0.89, pityCount));
+        difficultyOneIn = (int)Math.Ceiling(difficultyOneIn * Math.Pow(0.83, pityCount));
 
         // If there is no challenge present, allow it.
         if (difficultyOneIn == 1)

--- a/ProjectGagSpeak/Services/HardcoreEscapeService.cs
+++ b/ProjectGagSpeak/Services/HardcoreEscapeService.cs
@@ -1,6 +1,7 @@
 using GagSpeak.PlayerClient;
 using GagSpeak.Services.Mediator;
 using GagSpeak.State.Caches;
+using GagSpeak.WebAPI;
 using GagspeakAPI.Attributes;
 
 namespace GagSpeak.Services;
@@ -31,9 +32,22 @@ public class HardcoreEscapeService : DisposableMediatorSubscriberBase
 
         UpdateNextAllowedAttempt(0);
 
-        Mediator.Subscribe<GagStateChanged>(this, _ => _pityCounter = 0);
-        Mediator.Subscribe<RestrictionStateChanged>(this, _ => _pityCounter = 0);
-        Mediator.Subscribe<RestraintStateChanged>(this, _ => _pityCounter = 0);
+        Mediator.Subscribe<GagStateChanged>(this, e =>
+        {
+            if (e.Target == MainHub.UID) _pityCounter = 0;
+        });
+        Mediator.Subscribe<RestrictionStateChanged>(this, e =>
+        {
+            if (e.Target == MainHub.UID) _pityCounter = 0;
+        });
+        Mediator.Subscribe<RestraintStateChanged>(this, e =>
+        {
+            if (e.Target == MainHub.UID) _pityCounter = 0;
+        });
+        Mediator.Subscribe<RestraintLayersChanged>(this, e =>
+        {
+            if (e.Target == MainHub.UID) _pityCounter = 0;
+        });
     }
 
     public bool AttemptSelfRemove()

--- a/ProjectGagSpeak/Services/HardcoreEscapeService.cs
+++ b/ProjectGagSpeak/Services/HardcoreEscapeService.cs
@@ -16,7 +16,10 @@ public class HardcoreEscapeService : DisposableMediatorSubscriberBase
     private readonly TraitsCache _traits;
     private readonly Random _rand = new();
 
-    private DateTime _nextAllowedAttempt = DateTime.Now;
+    private DateTime
+        _nextAllowedAttempt =
+            DateTime.Now +
+            TimeSpan.FromMinutes(5); // Initial cooldown to avoid brats reloading the plugin to reset cooldown
     private int _pityCounter = 0;
     private const int MAX_PITY = 10;
 
@@ -30,8 +33,6 @@ public class HardcoreEscapeService : DisposableMediatorSubscriberBase
         _logger = logger;
         _config = config;
         _traits = traits;
-
-        UpdateNextAllowedAttempt(0);
 
         Mediator.Subscribe<GagStateChanged>(this, e =>
         {

--- a/ProjectGagSpeak/Services/HardcoreEscapeService.cs
+++ b/ProjectGagSpeak/Services/HardcoreEscapeService.cs
@@ -1,4 +1,5 @@
 using GagSpeak.PlayerClient;
+using GagSpeak.Services.Mediator;
 using GagSpeak.State.Caches;
 using GagspeakAPI.Attributes;
 
@@ -7,7 +8,7 @@ namespace GagSpeak.Services;
 /// <summary>
 ///   Handles the logic for escaping your own equippables.
 /// </summary>
-public class HardcoreEscapeService : IDisposable
+public class HardcoreEscapeService : DisposableMediatorSubscriberBase
 {
     private readonly ILogger<HardcoreEscapeService> _logger;
     private readonly MainConfig _config;
@@ -15,25 +16,31 @@ public class HardcoreEscapeService : IDisposable
     private readonly Random _rand = new();
 
     private DateTime _nextAllowedAttempt = DateTime.Now;
+    private int _pityCounter = 0;
 
     public bool HardcoreEscapeEnabled => _config.Data.HardcoreEscape;
     public bool CanDisable => _traits.FinalTraits == Traits.None;
 
-    public HardcoreEscapeService(ILogger<HardcoreEscapeService> logger, MainConfig config, TraitsCache traits)
+    public HardcoreEscapeService(
+        ILogger<HardcoreEscapeService> logger, MainConfig config, TraitsCache traits, GagspeakMediator mediator)
+        : base(logger, mediator)
     {
         _logger = logger;
         _config = config;
         _traits = traits;
 
         UpdateNextAllowedAttempt(0);
-    }
 
-    public void Dispose() { }
+        Mediator.Subscribe<GagStateChanged>(this, _ => _pityCounter = 0);
+        Mediator.Subscribe<RestrictionStateChanged>(this, _ => _pityCounter = 0);
+        Mediator.Subscribe<RestraintStateChanged>(this, _ => _pityCounter = 0);
+    }
 
     public bool AttemptSelfRemove()
     {
         // Hardcore escape not enabled, always allow
-        if (!HardcoreEscapeEnabled) return true;
+        if (!HardcoreEscapeEnabled)
+            return true;
 
         // One in X chance to succeed
         int difficultyOneIn = 1;
@@ -53,8 +60,18 @@ public class HardcoreEscapeService : IDisposable
                 difficultyOneIn += 5;
         }
 
+        var prePity = difficultyOneIn;
+        var pityCount = Math.Min(_pityCounter, 10);
+        // 0.9^0 = 1 => no change
+        // 0.9^10 ~= 0.34 => ~66% easier to escape at the end
+        difficultyOneIn = (int)Math.Ceiling(difficultyOneIn * Math.Pow(0.9, pityCount));
+
         // If there is no challenge present, allow it.
-        if (difficultyOneIn == 1) return true;
+        if (difficultyOneIn == 1)
+        {
+            _pityCounter = 0;
+            return true;
+        }
 
         // If cooldown is active, disallow it.
         if (DateTime.Now < _nextAllowedAttempt)
@@ -67,15 +84,18 @@ public class HardcoreEscapeService : IDisposable
         var roll = _rand.NextInt64(difficultyOneIn);
         UpdateNextAllowedAttempt(roll);
         _logger.LogDebug(
-            $"Attempted remove hardcore, difficulty one in {difficultyOneIn}, rolled {roll}. Next attempt allowed at {_nextAllowedAttempt}",
+            $"Attempted remove hardcore, difficulty one in {prePity} with pity {_pityCounter}=>{difficultyOneIn}, rolled {roll}. Next attempt allowed at {_nextAllowedAttempt}",
             LoggerType.HardcoreActions);
 
         if (roll > 0)
         {
-            Svc.Toasts.ShowError($"Failed to remove! You may try again in {CooldownString()}.");
+            Svc.Toasts.ShowError(
+                $"Failed to remove, but you feel a sense of progress! You may try again in {CooldownString()}.");
+            _pityCounter++;
             return false;
         }
 
+        _pityCounter = 0;
         return true;
     }
 

--- a/ProjectGagSpeak/Services/HardcoreEscapeService.cs
+++ b/ProjectGagSpeak/Services/HardcoreEscapeService.cs
@@ -124,9 +124,10 @@ public class HardcoreEscapeService : DisposableMediatorSubscriberBase
 
         // Add a small penalty for each active trait, simulating higher exhaustion from higher restriction
         var exhaustionCooldownMultiplier = 0;
-        for (int i = 1; i <= (1 << 6); i++)
+        for (int i = 1; i <= 6; i++)
         {
-            if (_traits.FinalTraits.HasFlag((Traits)i))
+            var trait = 1 << i;
+            if (_traits.FinalTraits.HasFlag((Traits)trait))
                 exhaustionCooldownMultiplier++;
         }
 

--- a/ProjectGagSpeak/Services/HardcoreEscapeService.cs
+++ b/ProjectGagSpeak/Services/HardcoreEscapeService.cs
@@ -18,6 +18,7 @@ public class HardcoreEscapeService : DisposableMediatorSubscriberBase
 
     private DateTime _nextAllowedAttempt = DateTime.Now;
     private int _pityCounter = 0;
+    private const int MAX_PITY = 10;
 
     public bool HardcoreEscapeEnabled => _config.Data.HardcoreEscape;
     public bool CanDisable => _traits.FinalTraits == Traits.None;
@@ -75,10 +76,10 @@ public class HardcoreEscapeService : DisposableMediatorSubscriberBase
         }
 
         var prePity = difficultyOneIn;
-        var pityCount = Math.Min(_pityCounter, 10);
+        var pityCount = Math.Min(_pityCounter, MAX_PITY);
         // 0.9^0 = 1 => no change
         // 0.9^10 ~= 0.34 => ~66% easier to escape at the end
-        difficultyOneIn = (int)Math.Ceiling(difficultyOneIn * Math.Pow(0.9, pityCount));
+        difficultyOneIn = (int)Math.Ceiling(difficultyOneIn * Math.Pow(0.89, pityCount));
 
         // If there is no challenge present, allow it.
         if (difficultyOneIn == 1)
@@ -96,16 +97,32 @@ public class HardcoreEscapeService : DisposableMediatorSubscriberBase
         }
 
         var roll = _rand.NextInt64(difficultyOneIn);
-        UpdateNextAllowedAttempt(roll);
+        var criticalFail = roll == difficultyOneIn - 1;
+        UpdateNextAllowedAttempt(roll, criticalFail);
         _logger.LogDebug(
             $"Attempted remove hardcore, difficulty one in {prePity} with pity {_pityCounter}=>{difficultyOneIn}, rolled {roll}. Next attempt allowed at {_nextAllowedAttempt}",
             LoggerType.HardcoreActions);
 
         if (roll > 0)
         {
-            Svc.Toasts.ShowError(
-                $"Failed to remove, but you feel a sense of progress! You may try again in {CooldownString()}.");
-            _pityCounter++;
+            if (criticalFail)
+            {
+                Svc.Toasts.ShowError(
+                    $"You make a mistake and the restraint tightens! You may try again in {CooldownString()}");
+                _pityCounter -= 2;
+                if (_pityCounter < 0) _pityCounter = 0;
+            }
+            else if (pityCount < MAX_PITY)
+            {
+                Svc.Toasts.ShowError(
+                    $"Failed to remove, but you feel a sense of progress! You may try again in {CooldownString()}.");
+                _pityCounter++;
+            }
+            else
+            {
+                Svc.Toasts.ShowError($"Failed to remove! You may try again in {CooldownString()}");
+            }
+
             return false;
         }
 
@@ -113,12 +130,12 @@ public class HardcoreEscapeService : DisposableMediatorSubscriberBase
         return true;
     }
 
-    private void UpdateNextAllowedAttempt(long roll)
+    private void UpdateNextAllowedAttempt(long roll, bool criticalFail = false)
     {
-        var baseCooldown = TimeSpan.FromMinutes(2);
+        var baseCooldown = TimeSpan.FromMinutes(1);
         if (roll == 0)
         {
-            _nextAllowedAttempt = DateTime.Now + (baseCooldown / 2);
+            _nextAllowedAttempt = DateTime.Now + baseCooldown;
             return;
         }
 
@@ -131,9 +148,13 @@ public class HardcoreEscapeService : DisposableMediatorSubscriberBase
                 exhaustionCooldownMultiplier++;
         }
 
-        var exhaustionCooldown = TimeSpan.FromSeconds(10) * exhaustionCooldownMultiplier;
-        var rollCooldown = TimeSpan.FromSeconds(2) * roll; // Max 86 seconds penalty for rolling poorly
+        var exhaustionCooldown = TimeSpan.FromSeconds(20) * exhaustionCooldownMultiplier;
+        var rollCooldown = TimeSpan.FromSeconds(10) * roll; // Add penalty for rolling poorly, worst possible roll is 43
         var cooldown = baseCooldown + rollCooldown + exhaustionCooldown;
+        if (criticalFail)
+        {
+            cooldown += rollCooldown;
+        }
         _nextAllowedAttempt = DateTime.Now + cooldown;
     }
 

--- a/ProjectGagSpeak/UI/Components/Drawers/ActiveItemsDrawer.cs
+++ b/ProjectGagSpeak/UI/Components/Drawers/ActiveItemsDrawer.cs
@@ -449,7 +449,10 @@ public class ActiveItemsDrawer
         ImUtf8.SameLineInner();
         //ImGui.SameLine(0,0);
         using var s = ImRaii.PushStyle(ImGuiStyleVar.FrameRounding, CkStyle.ChildRoundingLarge());
-        using var _ = ImRaii.Disabled(data.PadlockAssigner != MainHub.UID || data.Padlock == Padlocks.PredicamentTimer);
+        // Disable layer editing, when padlock was added by someone else, it's a predicament lock with no self-access, or any lock exists with hardcore escape turned on.
+        using var _ = ImRaii.Disabled(data.PadlockAssigner != MainHub.UID ||
+                                      data.Padlock == Padlocks.PredicamentTimer ||
+                                      (data.Padlock != Padlocks.None && _escape.HardcoreEscapeEnabled));
         using (ImRaii.Group())
         {
             // draw sync button, and call layer update if pressed.

--- a/ProjectGagSpeak/UI/Components/Drawers/ActiveItemsDrawer.cs
+++ b/ProjectGagSpeak/UI/Components/Drawers/ActiveItemsDrawer.cs
@@ -245,7 +245,8 @@ public class ActiveItemsDrawer
 
         // Draw out the potential popup if we should.
         var applyCombo = _gagItems[slotIdx];
-        if (_gagItems[slotIdx].DrawPopup($"##GagSelector-{slotIdx}", data.GagItem, rightWidth * .9f, drawPos))
+        if (_gagItems[slotIdx].DrawPopup($"##GagSelector-{slotIdx}", data.GagItem, rightWidth * .9f, drawPos) &&
+            _escape.AttemptSelfRemove())
             GagComboChanged(applyCombo, slotIdx, data.GagItem);
     }
 
@@ -283,7 +284,8 @@ public class ActiveItemsDrawer
 
         // Draw the potential popup if we should.
         var applyCombo = _restrictionItems[slotIdx];
-        if (applyCombo.DrawPopup($"##Restrictions-{slotIdx}", data.Identifier, rightWidth * .75f, drawPos))
+        if (applyCombo.DrawPopup($"##Restrictions-{slotIdx}", data.Identifier, rightWidth * .75f, drawPos) &&
+            _escape.AttemptSelfRemove())
             RestrictionComboChanged(applyCombo, slotIdx, data.Identifier);
     }
 
@@ -333,7 +335,10 @@ public class ActiveItemsDrawer
                 });
             }
         }
-        if (_restraintItem.DrawPopup($"##RestraintSetSelector", data.Identifier, ImGui.GetContentRegionAvail().X * .90f, drawPos))
+
+        if (_restraintItem.DrawPopup("##RestraintSetSelector", data.Identifier, ImGui.GetContentRegionAvail().X * .90f,
+                                     drawPos) &&
+            _escape.AttemptSelfRemove())
             RestraintComboChanged(data.Identifier);
     }
 

--- a/ProjectGagSpeak/UI/Components/Drawers/ActiveItemsDrawer.cs
+++ b/ProjectGagSpeak/UI/Components/Drawers/ActiveItemsDrawer.cs
@@ -497,10 +497,11 @@ public class ActiveItemsDrawer
         if (nickEnabler is null && enabler == MainHub.UID)
             nickEnabler = "yourself";
 
+        var swapLabel = _escape.HardcoreEscapeEnabled ? "Attempt to swap to" : "Select";
         var clearLabel = _escape.HardcoreEscapeEnabled ? "Attempt to escape" : "Clear";
 
         return $"{label ?? "Unknown item"} applied by {nickEnabler ?? "Unknown Kinkster"}" +
-               $"--SEP----COL--Left-Click--COL-- ⇒ Select another {itemType} Item." +
+               $"--SEP----COL--Left-Click--COL-- ⇒ {swapLabel} another {itemType} Item." +
                $"--NL----COL--Right-Click--COL-- ⇒ {clearLabel} active {itemType} Item.";
     }
 


### PR DESCRIPTION
- Prevent toggling layers while HC escape applies
- Prevent swapping items without passing the check while HC escape applies
- Added pity system to make escape easier (but not guaranteed) based on number of failures since the last success or equipment change.
- Fixed exhaustion cooldown being longer than intended
- Added critical fails
- Changed cooldown between attempts to have a wider range of durations based on the outcome of the dice roll.