### PR TITLE
feat: trigger lock actions can target a specific item

### DIFF
--- a/ProjectGagSpeak/Triggers/ReactionDistributor.cs
+++ b/ProjectGagSpeak/Triggers/ReactionDistributor.cs
@@ -229,22 +229,14 @@ public class ReactionDistributor
             if (act.Padlock is Padlocks.None)
                 return false;
 
-            // If we have defined a layer idx, look for a gag on that index and return false if none are present or it is locked.
-            if (act.LayerIdx != -1)
-            {
-                if (gagData.GagSlots[act.LayerIdx].IsLocked() || gagData.GagSlots[act.LayerIdx].GagItem is GagType.None)
-                    return false;
-            }
-
-            // If we have selected a specific gag to lock, look for it, and if none are found, return false.
-            if (act.GagType is not GagType.None && gagData.FindOutermostActive(act.GagType) is -1)
-                return false;
-
-            // Otherwise, attempt to locate the first lockable gagslot.
+            // Any layer: locate the chosen gag when one is set, otherwise the outermost lockable one.
             if (layerIdx is -1)
-                layerIdx = gagData.FindFirstUnlocked();
+                layerIdx = act.GagType is GagType.None ? gagData.FindOutermostActive() : gagData.FindOutermostActive(act.GagType);
+            // Specific layer: it must hold an unlocked gag matching the chosen gag type when one is set.
+            else if (gagData.GagSlots[layerIdx].GagItem is GagType.None || gagData.GagSlots[layerIdx].IsLocked()
+                || (act.GagType is not GagType.None && gagData.GagSlots[layerIdx].GagItem != act.GagType))
+                layerIdx = -1;
 
-            // If still not valid, fail.
             if (layerIdx is -1)
                 return false;
 
@@ -268,7 +260,7 @@ public class ReactionDistributor
                     timer = Generators.GetRandomTimeSpan(act.LowerBound, act.UpperBound);
             }
 
-            _logger.LogInformation($"Locking [{act.GagType}] with [{act.Padlock}] on layer {layerIdx}", LoggerType.Triggers);
+            _logger.LogInformation($"Locking [{gagData.GagSlots[layerIdx].GagItem}] with [{act.Padlock}] on layer {layerIdx}", LoggerType.Triggers);
             var gagSlot = gagData.GagSlots[layerIdx] with
             {
                 Padlock = act.Padlock,
@@ -325,9 +317,20 @@ public class ReactionDistributor
         }
         else if (act.NewState is NewState.Locked)
         {
-            layerIdx = act.LayerIdx == -1 ? restrictions.Restrictions.IndexOf(x => x.Identifier != Guid.Empty && x.CanLock()) : act.LayerIdx;
+            if (act.Padlock is Padlocks.None)
+                return false;
 
-            if (layerIdx is -1 || !restrictions.Restrictions[layerIdx].CanLock() || act.Padlock is Padlocks.None)
+            // Any layer: locate the chosen restriction when one is set, otherwise the outermost lockable one.
+            if (layerIdx is -1)
+                layerIdx = act.RestrictionId != Guid.Empty
+                    ? Array.FindLastIndex(restrictions.Restrictions, x => x.Identifier == act.RestrictionId && x.CanLock())
+                    : restrictions.FindOutermostActiveUnlocked();
+            // Specific layer: it must hold a restriction matching the chosen one when set.
+            else if (restrictions.Restrictions[layerIdx].Identifier == Guid.Empty
+                || (act.RestrictionId != Guid.Empty && restrictions.Restrictions[layerIdx].Identifier != act.RestrictionId))
+                layerIdx = -1;
+
+            if (layerIdx is -1 || !restrictions.Restrictions[layerIdx].CanLock())
                 return false;
 
             var timer = TimeSpan.Zero;
@@ -340,7 +343,7 @@ public class ReactionDistributor
                     timer = Generators.GetRandomTimeSpan(act.LowerBound, act.UpperBound);
             }
 
-            _logger.LogInformation($"Locking restriction [{act.RestrictionId}] with [{act.Padlock}] on layer {layerIdx}", LoggerType.Triggers);
+            _logger.LogInformation($"Locking restriction [{restrictions.Restrictions[layerIdx].Identifier}] with [{act.Padlock}] on layer {layerIdx}", LoggerType.Triggers);
             var itemSlot = restrictions.Restrictions[layerIdx] with
             {
                 Padlock = act.Padlock,
@@ -399,7 +402,12 @@ public class ReactionDistributor
         }
         else if (act.NewState is NewState.Locked)
         {
-            if (!restraint.CanLock() || act.Padlock is Padlocks.None)
+            if (act.Padlock is Padlocks.None)
+                return false;
+            // When a specific set is chosen, only lock if it is the currently active one.
+            if (act.RestrictionId != Guid.Empty && restraint.Identifier != act.RestrictionId)
+                return false;
+            if (!restraint.CanLock())
                 return false;
 
             var timer = TimeSpan.Zero;
@@ -412,7 +420,7 @@ public class ReactionDistributor
                     timer = Generators.GetRandomTimeSpan(act.LowerBound, act.UpperBound);
             }
 
-            _logger.LogDebug($"Locking restraint [{act.RestrictionId}] with [{act.Padlock}]", LoggerType.Triggers);
+            _logger.LogDebug($"Locking restraint [{restraint.Identifier}] with [{act.Padlock}]", LoggerType.Triggers);
             var setData = restraint with
             {
                 Padlock = act.Padlock,

--- a/ProjectGagSpeak/UI/Components/Drawers/ReactionsDrawer.cs
+++ b/ProjectGagSpeak/UI/Components/Drawers/ReactionsDrawer.cs
@@ -164,6 +164,11 @@ public sealed class ReactionsDrawer
         }
 
         // Lock state
+        ImGui.Image(CosmeticService.CoreTextures.Cache[CoreTexture.Gagged].Handle, new(ImUtf8.FrameHeight));
+        CkGui.AttachTooltip("Indicates what gag is locked.");
+        CkGui.TextFrameAlignedInline("Targeting");
+        CkGui.ColorTextFrameAlignedInline(act.GagType is GagType.None ? "Any Gag" : act.GagType.GagName(), ImGuiColors.TankBlue);
+
         CkGui.FramedIconText(FAI.Lock);
         CkGui.AttachTooltip("Indicates what lock will be applied to the gag.");
         CkGui.TextFrameAlignedInline("Using a");
@@ -189,6 +194,11 @@ public sealed class ReactionsDrawer
         CkGui.ColorTextFrameAlignedInline(isLockAndKey ? act.Padlock.ToName() : (act.GagType is GagType.None ? "Any Gag" : act.GagType.GagName()), ImGuiColors.TankBlue);
         CkGui.TextFrameAlignedInline("will be");
         CkGui.ColorTextFrameAlignedInline(act.NewState.ToName(), ImGuiColors.TankBlue);
+        if (isLockAndKey)
+        {
+            CkGui.TextFrameAlignedInline("on");
+            CkGui.ColorTextFrameAlignedInline(act.GagType is GagType.None ? "any gag" : act.GagType.GagName(), ImGuiColors.TankBlue);
+        }
         if (!act.IsValid())
         {
             ImGui.SameLine();
@@ -244,6 +254,14 @@ public sealed class ReactionsDrawer
         }
 
         // Lock state
+        ImGui.Image(CosmeticService.CoreTextures.Cache[CoreTexture.Gagged].Handle, new(ImUtf8.FrameHeight));
+        CkGui.AttachTooltip("Indicates what gag will be locked.");
+        CkGui.TextFrameAlignedInline("Targeting");
+
+        ImUtf8.SameLineInner();
+        if (CkGuiUtils.EnumCombo("##edit-gag-lock", width, act.GagType, out var lockGag, i => i switch { GagType.None => "Any Gag", _ => i.GagName() }, flags: CFlags.NoArrowButton))
+            act.GagType = lockGag;
+
         CkGui.FramedIconText(FAI.Lock);
         CkGui.AttachTooltip("Indicates what lock will be applied to the gag.");
         CkGui.TextFrameAlignedInline("Using a");
@@ -295,24 +313,23 @@ public sealed class ReactionsDrawer
             act.NewState = newState;
         CkGui.AttachTooltip("The new state set on the targeted gag.");
 
-        if (newState is NewState.Locked)
+        if (act.NewState is NewState.Locked)
         {
             ImUtf8.SameLineInner();
             var options = PadlockEx.ClientLocks.Except(PadlockEx.PasswordPadlocks);
-            if (CkGuiUtils.EnumCombo("##PadlockType", 100f, act.Padlock, out var newVal, options, i => i.ToName(), flags: CFlags.NoArrowButton))
-                act.Padlock = newVal;
+            if (CkGuiUtils.EnumCombo("##PadlockType", 100f, act.Padlock, out var newLock, options, i => i.ToName(), flags: CFlags.NoArrowButton))
+                act.Padlock = newLock;
 
             if (act.Padlock.IsTimerLock())
             {
                 CkGui.TextFrameAlignedInline("[TBD]");
             }
         }
-        else
-        {
-            ImUtf8.SameLineInner();
-            if (CkGuiUtils.EnumCombo("##GagType", 100f, act.GagType, out var newVal, i => i switch { GagType.None => "Any Gag", _ => i.GagName() }, flags: CFlags.NoArrowButton))
-                act.GagType = newVal;
-        }
+
+        ImUtf8.SameLineInner();
+        if (CkGuiUtils.EnumCombo("##GagType", 100f, act.GagType, out var newVal, i => i switch { GagType.None => "Any Gag", _ => i.GagName() }, flags: CFlags.NoArrowButton))
+            act.GagType = newVal;
+        CkGui.AttachTooltip("The gag targeted by this action.");
 
         ImUtf8.SameLineInner();
         var width = ImGui.GetContentRegionAvail().X - CkGui.IconButtonSize(FAI.Minus).X;
@@ -351,6 +368,12 @@ public sealed class ReactionsDrawer
         }
 
         // Lock state
+        CkGui.FramedIconText(FAI.Handcuffs);
+        CkGui.AttachTooltip("Indicates what restriction is locked.");
+        CkGui.TextFrameAlignedInline("Targeting");
+        var lockItem = _restrictions.Storage.FirstOrDefault(r => r.Identifier == act.RestrictionId);
+        CkGui.ColorTextFrameAlignedInline(act.RestrictionId == Guid.Empty ? "Any Restriction" : (lockItem is { } li ? li.Label.TrimText(50) : "<UNK>"), ImGuiColors.TankBlue);
+
         CkGui.FramedIconText(FAI.Lock);
         CkGui.AttachTooltip("Indicates what lock will be applied to the restriction.");
         CkGui.TextFrameAlignedInline("Uses a");
@@ -381,17 +404,15 @@ public sealed class ReactionsDrawer
                 CkGui.ColorTextFrameAlignedInline($"{(act.LayerIdx is -1 ? "any layer" : $"layer {act.LayerIdx}")}", ImGuiColors.TankBlue);
                 break;
             case NewState.Locked:
+                var lockItem = _restrictions.Storage.FirstOrDefault(r => r.Identifier == act.RestrictionId);
                 CkGui.TextFrameAligned("Use a");
                 CkGui.ColorTextFrameAlignedInline(act.Padlock.ToName(), ImGuiColors.TankBlue);
+                CkGui.TextFrameAlignedInline("on the");
+                CkGui.ColorTextFrameAlignedInline(act.RestrictionId == Guid.Empty ? "restriction" : (lockItem is { } li ? li.Label.TrimText(20) : "<UNK>"), ImGuiColors.TankBlue);
+                CkGui.AttachTooltip(lockItem?.Label, lockItem is null);
                 CkGui.TextFrameAlignedInline("on");
-                if (act.LayerIdx is -1)
-                    CkGui.ColorTextFrameAlignedInline("any unlocked restriction", ImGuiColors.TankBlue);
-                else
-                {
-                    CkGui.TextFrameAlignedInline("on");
-                    CkGui.ColorTextFrameAlignedInline($"layer {act.LayerIdx}'s restriction", ImGuiColors.TankBlue);
-                    CkGui.TextFrameAlignedInline("if unlocked");
-                }
+                CkGui.ColorTextFrameAlignedInline(act.LayerIdx is -1 ? "any layer" : $"layer {act.LayerIdx}", ImGuiColors.TankBlue);
+                CkGui.TextFrameAlignedInline("if unlocked");
                 break;
             case NewState.Disabled:
                 var remItem = _restrictions.Storage.FirstOrDefault(r => r.Identifier == act.RestrictionId);
@@ -465,6 +486,16 @@ public sealed class ReactionsDrawer
         }
 
         // Lock state
+        CkGui.FramedIconText(FAI.Handcuffs);
+        CkGui.AttachTooltip("Indicates what restriction will be locked.--SEP--Right-Click to clear, targeting any restriction.");
+        CkGui.TextFrameAlignedInline("Targeting");
+
+        ImUtf8.SameLineInner();
+        if (_restrictionCombo.Draw("##restrictions-lock", act.RestrictionId, ImGui.GetContentRegionAvail().X))
+            act.RestrictionId = _restrictionCombo.Current?.Identifier ?? Guid.Empty;
+        if (ImGui.IsItemClicked(ImGuiMouseButton.Right))
+            act.RestrictionId = Guid.Empty;
+
         CkGui.FramedIconText(FAI.Lock);
         CkGui.AttachTooltip("Indicates what lock will be applied to the restriction.");
         CkGui.TextFrameAlignedInline("Using a");
@@ -516,7 +547,7 @@ public sealed class ReactionsDrawer
             act.NewState = newState;
         CkGui.AttachTooltip("The new state set on the targeted restriction item.");
 
-        if (newState is NewState.Locked)
+        if (act.NewState is NewState.Locked)
         {
             ImUtf8.SameLineInner();
             var options = PadlockEx.ClientLocks.Except(PadlockEx.PasswordPadlocks);
@@ -528,15 +559,16 @@ public sealed class ReactionsDrawer
                 CkGui.TextFrameAlignedInline("[TBD]");
             }
         }
-        else
+
+        ImUtf8.SameLineInner();
+        if (_restrictionCombo.Draw("##RestrictSel", act.RestrictionId, 120f, CFlags.NoArrowButton))
         {
-            ImUtf8.SameLineInner();
-            if (_restrictionCombo.Draw("##RestrictSel", act.RestrictionId, 120f, CFlags.NoArrowButton))
-            {
-                if (!act.RestrictionId.Equals(_restrictionCombo.Current?.Identifier))
-                    act.RestrictionId = _restrictionCombo.Current?.Identifier ?? Guid.Empty;
-            }
+            if (!act.RestrictionId.Equals(_restrictionCombo.Current?.Identifier))
+                act.RestrictionId = _restrictionCombo.Current?.Identifier ?? Guid.Empty;
         }
+        if (ImGui.IsItemClicked(ImGuiMouseButton.Right))
+            act.RestrictionId = Guid.Empty;
+        CkGui.AttachTooltip("The restriction targeted by this action.--SEP--Right-Click to clear, targeting any restriction.");
 
         ImUtf8.SameLineInner();
         var width = ImGui.GetContentRegionAvail().X - CkGui.IconButtonSize(FAI.Minus).X;
@@ -581,8 +613,14 @@ public sealed class ReactionsDrawer
         }
 
         // Lock state
+        CkGui.FramedIconText(FAI.Handcuffs);
+        CkGui.AttachTooltip("Indicates what restraint set is locked.");
+        CkGui.TextFrameAlignedInline("Targeting");
+        var lockItem = _restraints.Storage.FirstOrDefault(r => r.Identifier == act.RestrictionId);
+        CkGui.ColorTextFrameAlignedInline(act.RestrictionId == Guid.Empty ? "Any Restraint Set" : (lockItem is { } ls ? ls.Label.TrimText(50) : "<UNK>"), ImGuiColors.TankBlue);
+
         CkGui.FramedIconText(FAI.Lock);
-        CkGui.AttachTooltip("Indicates what lock will be applied to the restriction.");
+        CkGui.AttachTooltip("Indicates what lock will be applied to the restraint set.");
         CkGui.TextFrameAlignedInline("Uses a");
         CkGui.ColorTextFrameAlignedInline(act.Padlock.ToName(), ImGuiColors.TankBlue);
         if (act.Padlock.IsTimerLock() && act.Padlock is not Padlocks.FiveMinutes)
@@ -615,9 +653,13 @@ public sealed class ReactionsDrawer
                 CkGui.TextFrameAlignedInline("if not locked");
                 break;
             case NewState.Locked:
+                var lockItem = _restraints.Storage.FirstOrDefault(r => r.Identifier == act.RestrictionId);
                 CkGui.TextFrameAligned("Use a");
                 CkGui.ColorTextFrameAlignedInline(act.Padlock.ToName(), ImGuiColors.TankBlue);
-                CkGui.TextFrameAlignedInline("on an unlocked, applied restraint");
+                CkGui.TextFrameAlignedInline("on the");
+                CkGui.ColorTextFrameAlignedInline(act.RestrictionId == Guid.Empty ? "active restraint set" : (lockItem is { } ls ? ls.Label.TrimText(20) : "<UNK>"), ImGuiColors.TankBlue);
+                CkGui.AttachTooltip(lockItem?.Label, lockItem is null);
+                CkGui.TextFrameAlignedInline("if unlocked and present");
                 break;
             case NewState.Disabled:
                 var remItem = _restraints.Storage.FirstOrDefault(r => r.Identifier == act.RestrictionId);
@@ -682,6 +724,16 @@ public sealed class ReactionsDrawer
         }
 
         // Lock state
+        CkGui.FramedIconText(FAI.Handcuffs);
+        CkGui.AttachTooltip("Indicates what restraint set will be locked.--SEP--Right-Click to clear, targeting any restraint set.");
+        CkGui.TextFrameAlignedInline("Targeting");
+
+        ImUtf8.SameLineInner();
+        if (_restraintCombo.Draw("##restraints-lock", act.RestrictionId, ImGui.GetContentRegionAvail().X))
+            act.RestrictionId = _restraintCombo.Current?.Identifier ?? Guid.Empty;
+        if (ImGui.IsItemClicked(ImGuiMouseButton.Right))
+            act.RestrictionId = Guid.Empty;
+
         CkGui.FramedIconText(FAI.Lock);
         CkGui.AttachTooltip("Indicates what lock will be applied to the restraint set.");
         CkGui.TextFrameAlignedInline("Using a");
@@ -733,7 +785,7 @@ public sealed class ReactionsDrawer
             act.NewState = newState;
         CkGui.AttachTooltip("The new state set on the chosen restraint set.");
 
-        if (newState is NewState.Locked)
+        if (act.NewState is NewState.Locked)
         {
             ImUtf8.SameLineInner();
             var options = PadlockEx.ClientLocks.Except(PadlockEx.PasswordPadlocks);
@@ -746,20 +798,19 @@ public sealed class ReactionsDrawer
                 // Implement timer shit later i guess.
             }
         }
-        else
-        {
-            ImUtf8.SameLineInner();
-            if (_restraintCombo.Draw("##RestraintSelector", act.RestrictionId, 120f, CFlags.NoArrowButton))
-            {
-                if (!act.RestrictionId.Equals(_restraintCombo.Current?.Identifier))
-                    act.RestrictionId = _restraintCombo.Current?.Identifier ?? Guid.Empty;
-            }
-            if (ImGui.IsItemClicked(ImGuiMouseButton.Right))
-                act.RestrictionId = Guid.Empty;
 
-            if (act.NewState is NewState.Enabled)
-                DrawRestraintLayerCheckboxes(act, sameLine: true);
+        ImUtf8.SameLineInner();
+        if (_restraintCombo.Draw("##RestraintSelector", act.RestrictionId, 120f, CFlags.NoArrowButton))
+        {
+            if (!act.RestrictionId.Equals(_restraintCombo.Current?.Identifier))
+                act.RestrictionId = _restraintCombo.Current?.Identifier ?? Guid.Empty;
         }
+        if (ImGui.IsItemClicked(ImGuiMouseButton.Right))
+            act.RestrictionId = Guid.Empty;
+        CkGui.AttachTooltip("The restraint set targeted by this action.--SEP--Right-Click to clear, targeting any restraint set.");
+
+        if (act.NewState is NewState.Enabled)
+            DrawRestraintLayerCheckboxes(act, sameLine: true);
     }
 
     /// <summary> Lists the layers enabled on apply as "N: Label", falling back to the number alone when unnamed. </summary>


### PR DESCRIPTION
Gave the lock action for gags, restrictions and restraints triggers the ability to select a specific item for the lock to mirror the same update for the Remove action