### PR TITLE
Fix restraint layers not applying visually when only a Penumbra mod setting changes

### DIFF
--- a/ProjectGagSpeak/State/Managers/CacheManagers/CacheStateManager.cs
+++ b/ProjectGagSpeak/State/Managers/CacheManagers/CacheStateManager.cs
@@ -503,6 +503,10 @@ public class CacheStateManager : IHostedService
             _arousalHandler.UpdateFinalCache(),
             _overlayHandler.UpdateCaches()
         );
+
+        // Handle Redraw afterwards
+        if (item.DoRedraw)
+            _redrawAssist.RedrawObject();
     }
 
     public async Task AddRestraintSetLayers(RestraintSet item, RestraintLayer added, string enactor)
@@ -540,6 +544,10 @@ public class CacheStateManager : IHostedService
             _arousalHandler.UpdateFinalCache(),
             _overlayHandler.UpdateCaches()
         );
+
+        // Handle Redraw afterwards
+        if (item.DoRedraw)
+            _redrawAssist.RedrawObject();
     }
 
     // I can almost guarantee that removing this without considering for any
@@ -601,6 +609,10 @@ public class CacheStateManager : IHostedService
             _arousalHandler.UpdateFinalCache(),
             _overlayHandler.UpdateCaches()
         );
+
+        // Handle Redraw afterwards
+        if (item.DoRedraw)
+            _redrawAssist.RedrawObject();
     }
 
     // For CURSED ITEMS.


### PR DESCRIPTION
## Problem
Applying, swapping, or removing an individual restraint set layer didn't
visually update the character when the layer's only change was a Penumbra
mod setting (no equipment/glamour change). The setting gets correctly sent
to Penumbra, but nothing forces the game to re-resolve files for it, so it
stays invisible until some unrelated action (re-applying the base set,
gear change, zone transfer, etc.) happens to trigger a redraw.

## Fix
Add the same `if (item.DoRedraw) _redrawAssist.RedrawObject();` block used
elsewhere to the end of all three layer methods.
