### PR TITLE
add IPCExtensions

### DIFF
--- a/ProjectGagSpeak/Interop/Ipc/IpcCallerLoci.cs
+++ b/ProjectGagSpeak/Interop/Ipc/IpcCallerLoci.cs
@@ -1,3 +1,5 @@
+using Dalamud.Plugin.Ipc.Exceptions;
+using GagSpeak.Interop.Helpers;
 using GagSpeak.Services.Mediator;
 using LociApi.Enums;
 using LociApi.Helpers;
@@ -146,7 +148,7 @@ public sealed class IpcCallerLoci : IIpcCaller
     public async Task<bool> RegisterActor(nint address)
     {
         if (!APIAvailable) return false;
-        var res = await Svc.Framework.RunOnFrameworkThread(() => Register.Invoke(address, GAGSPEAK_TAG)).ConfigureAwait(false);
+        var res = await Svc.Framework.InvokeIPC(() => Register.Invoke(address, GAGSPEAK_TAG), LociApiEc.UnkError).ConfigureAwait(false);
         if (res is not (LociApiEc.Success or LociApiEc.NoChange))
             _logger.LogWarning($"Loci Failed to register Actor {address} with Loci! Error: {res}");
         return res is (LociApiEc.Success or LociApiEc.NoChange);
@@ -156,7 +158,7 @@ public sealed class IpcCallerLoci : IIpcCaller
     public async Task<bool> RegisterPlayer(string playerNameWorld)
     {
         if (!APIAvailable) return false;
-        var res = await Svc.Framework.RunOnFrameworkThread(() => RegisterName.Invoke(playerNameWorld, GAGSPEAK_TAG)).ConfigureAwait(false);
+        var res = await Svc.Framework.InvokeIPC(() => RegisterName.Invoke(playerNameWorld, GAGSPEAK_TAG), LociApiEc.UnkError).ConfigureAwait(false);
         if (res is not (LociApiEc.Success or LociApiEc.NoChange))
             _logger.LogWarning($"Loci Failed to register Player {playerNameWorld} with Loci! Error: {res}");
         return res is (LociApiEc.Success or LociApiEc.NoChange);
@@ -166,7 +168,7 @@ public sealed class IpcCallerLoci : IIpcCaller
     public async Task UnregisterActor(nint address)
     {
         if (!APIAvailable) return;
-        await Svc.Framework.RunOnFrameworkThread(() => Unregister.Invoke(address, GAGSPEAK_TAG)).ConfigureAwait(false);
+        await Svc.Framework.InvokeIPC(() => Unregister.Invoke(address, GAGSPEAK_TAG), default).ConfigureAwait(false);
     }
 
     /// <inheritdoc cref="LociApi.Ipc.UnregisterByName"/>
@@ -187,49 +189,49 @@ public sealed class IpcCallerLoci : IIpcCaller
     public async Task<string> GetOwnManagerStr()
     {
         if (!APIAvailable) return string.Empty;
-        return await Svc.Framework.RunOnFrameworkThread(() => GetManager.Invoke().Item2 ?? string.Empty).ConfigureAwait(false);
+        return await Svc.Framework.InvokeIPC(() => GetManager.Invoke().Item2 ?? string.Empty, string.Empty).ConfigureAwait(false);
     }
 
     /// <inheritdoc cref="LociApi.Ipc.GetManagerByPtr"/>
     public async Task<string> GetActorSMStr(nint actorAddr)
     {
         if (!APIAvailable) return string.Empty;
-        return await Svc.Framework.RunOnFrameworkThread(() => GetManagerByPtr.Invoke(actorAddr).Item2 ?? string.Empty).ConfigureAwait(false);
+        return await Svc.Framework.InvokeIPC(() => GetManagerByPtr.Invoke(actorAddr).Item2 ?? string.Empty, string.Empty).ConfigureAwait(false);
     }
 
     /// <inheritdoc cref="LociApi.Ipc.GetManagerInfo"/>
     public async Task<List<LociStatusInfo>> GetOwnManagerInfo()
     {
         if (!APIAvailable) return [];
-        return await Svc.Framework.RunOnFrameworkThread(() => GetManagerInfo.Invoke()).ConfigureAwait(false);
+        return await Svc.Framework.InvokeIPC(() => GetManagerInfo.Invoke(), []).ConfigureAwait(false);
     }
 
     /// <inheritdoc cref="LociApi.Ipc.GetManagerInfoByPtr"/>
     public async Task<List<LociStatusInfo>> GetActorSMInfo(nint actorAddr)
     {
         if (!APIAvailable) return [];
-        return await Svc.Framework.RunOnFrameworkThread(() => GetManagerInfoByPtr.Invoke(actorAddr)).ConfigureAwait(false);
+        return await Svc.Framework.InvokeIPC(() => GetManagerInfoByPtr.Invoke(actorAddr), []).ConfigureAwait(false);
     }
 
     /// <inheritdoc cref="LociApi.Ipc.GetStatusInfo"/>
     public async Task<LociStatusInfo> GetStatusInfo(Guid guid)
     {
         if (!APIAvailable) return default;
-        return await Svc.Framework.RunOnFrameworkThread(() => GetStatusTuple.Invoke(guid).Item2).ConfigureAwait(false);
+        return await Svc.Framework.InvokeIPC(() => GetStatusTuple.Invoke(guid).Item2, default).ConfigureAwait(false);
     }
 
     /// <inheritdoc cref="LociApi.Ipc.GetStatusInfoList"/>
     public async Task<List<LociStatusInfo>> GetStatusInfos()
     {
         if (!APIAvailable) return [];
-        return await Svc.Framework.RunOnFrameworkThread(GetAllStatuseTuples.Invoke).ConfigureAwait(false);
+        return await Svc.Framework.InvokeIPC(GetAllStatuseTuples.Invoke, []).ConfigureAwait(false);
     }
 
     /// <inheritdoc cref="LociApi.Ipc.ApplyStatus"/>
     public async Task<bool> ApplyStatus(Guid id, bool asLocked)
     {
         if (!APIAvailable) return false;
-        var res = await Svc.Framework.RunOnFrameworkThread(() => ApplyStatusById.Invoke(id, asLocked ? GAGSPEAK_KEY : 0)).ConfigureAwait(false);
+        var res = await Svc.Framework.InvokeIPC(() => ApplyStatusById.Invoke(id, asLocked ? GAGSPEAK_KEY : 0), LociApiEc.UnkError).ConfigureAwait(false);
         return res is (LociApiEc.Success or LociApiEc.PartialSuccess);
     }
 
@@ -237,7 +239,7 @@ public sealed class IpcCallerLoci : IIpcCaller
     public async Task<bool> ApplyStatus(List<Guid> ids, bool asLocked)
     {
         if (!APIAvailable) return false;
-        var res = await Svc.Framework.RunOnFrameworkThread(() => ApplyStatusByIds.Invoke(ids, asLocked ? GAGSPEAK_KEY : 0, out _)).ConfigureAwait(false);
+        var res = await Svc.Framework.InvokeIPC(() => ApplyStatusByIds.Invoke(ids, asLocked ? GAGSPEAK_KEY : 0, out _), LociApiEc.UnkError).ConfigureAwait(false);
         return res is (LociApiEc.Success or LociApiEc.PartialSuccess);
     }
 
@@ -245,7 +247,7 @@ public sealed class IpcCallerLoci : IIpcCaller
     public async Task<bool> ApplyStatusInfo(LociStatusInfo tuple, bool asLocked)
     {
         if (!APIAvailable) return false;
-        var res = await Svc.Framework.RunOnFrameworkThread(() => ApplyStatusTuple.Invoke(tuple, asLocked ? GAGSPEAK_KEY : 0)).ConfigureAwait(false);
+        var res = await Svc.Framework.InvokeIPC(() => ApplyStatusTuple.Invoke(tuple, asLocked ? GAGSPEAK_KEY : 0), LociApiEc.UnkError).ConfigureAwait(false);
         return res is (LociApiEc.Success or LociApiEc.PartialSuccess);
     }
 
@@ -253,7 +255,7 @@ public sealed class IpcCallerLoci : IIpcCaller
     public async Task<bool> ApplyStatusInfo(List<LociStatusInfo> tuples, bool asLocked)
     {
         if (!APIAvailable) return false;
-        var res = await Svc.Framework.RunOnFrameworkThread(() => ApplyStatusTuples.Invoke(tuples, asLocked ? GAGSPEAK_KEY : 0)).ConfigureAwait(false);
+        var res = await Svc.Framework.InvokeIPC(() => ApplyStatusTuples.Invoke(tuples, asLocked ? GAGSPEAK_KEY : 0), LociApiEc.UnkError).ConfigureAwait(false);
         return res is (LociApiEc.Success or LociApiEc.PartialSuccess);
     }
 
@@ -261,7 +263,7 @@ public sealed class IpcCallerLoci : IIpcCaller
     public async Task<bool> BombStatus(Guid id, bool useKey)
     {
         if (!APIAvailable) return false;
-        var res = await Svc.Framework.RunOnFrameworkThread(() => RemoveStatus.Invoke(id, useKey ? GAGSPEAK_KEY : 0)).ConfigureAwait(false);
+        var res = await Svc.Framework.InvokeIPC(() => RemoveStatus.Invoke(id, useKey ? GAGSPEAK_KEY : 0), LociApiEc.UnkError).ConfigureAwait(false);
         return res is (LociApiEc.Success or LociApiEc.PartialSuccess);
     }
 
@@ -269,7 +271,7 @@ public sealed class IpcCallerLoci : IIpcCaller
     public async Task<bool> BombStatus(List<Guid> ids, bool useKey)
     {
         if (!APIAvailable) return false;
-        var res = await Svc.Framework.RunOnFrameworkThread(() => RemoveStatuses.Invoke(ids, useKey ? GAGSPEAK_KEY : 0, out _)).ConfigureAwait(false);
+        var res = await Svc.Framework.InvokeIPC(() => RemoveStatuses.Invoke(ids, useKey ? GAGSPEAK_KEY : 0, out _), LociApiEc.UnkError).ConfigureAwait(false);
         return res is (LociApiEc.Success or LociApiEc.PartialSuccess);
     }
 
@@ -277,28 +279,28 @@ public sealed class IpcCallerLoci : IIpcCaller
     public async Task<LociPresetInfo> GetPresetInfo(Guid guid)
     {
         if (!APIAvailable) return default;
-        return await Svc.Framework.RunOnFrameworkThread(() => GetPresetTuple.Invoke(guid).Item2).ConfigureAwait(false);
+        return await Svc.Framework.InvokeIPC(() => GetPresetTuple.Invoke(guid).Item2, default).ConfigureAwait(false);
     }
 
     /// <inheritdoc cref="LociApi.Ipc.GetPresetInfoList"/>
     public async Task<List<LociPresetInfo>> GetPresetInfos()
     {
         if (!APIAvailable) return [];
-        return await Svc.Framework.RunOnFrameworkThread(GetAllPresetTuples.Invoke).ConfigureAwait(false);
+        return await Svc.Framework.InvokeIPC(GetAllPresetTuples.Invoke, []).ConfigureAwait(false);
     }
 
     /// <inheritdoc cref="LociApi.Ipc.ApplyPreset"/>
     public async Task<bool> ApplyPreset(Guid id, bool asLocked)
     {
         if (!APIAvailable) return false;
-        var res = await Svc.Framework.RunOnFrameworkThread(() => ApplyPresetById.Invoke(id, asLocked ? GAGSPEAK_KEY : 0)).ConfigureAwait(false);
+        var res = await Svc.Framework.InvokeIPC(() => ApplyPresetById.Invoke(id, asLocked ? GAGSPEAK_KEY : 0),LociApiEc.UnkError).ConfigureAwait(false);
         return res is (LociApiEc.Success or LociApiEc.PartialSuccess);
     }
 
     public async Task<bool> ApplyPreset(List<Guid> ids, bool asLocked)
     {
         if (!APIAvailable) return false;
-        var res = await Svc.Framework.RunOnFrameworkThread(() => ApplyPresetByIds.Invoke(ids, asLocked ? GAGSPEAK_KEY : 0, out _)).ConfigureAwait(false);
+        var res = await Svc.Framework.InvokeIPC(() => ApplyPresetByIds.Invoke(ids, asLocked ? GAGSPEAK_KEY : 0, out _),LociApiEc.UnkError).ConfigureAwait(false);
         return res is (LociApiEc.Success or LociApiEc.PartialSuccess);
     }
 
@@ -306,7 +308,7 @@ public sealed class IpcCallerLoci : IIpcCaller
     public async Task ApplyPresetInfo(LociPresetInfo tuple, bool asLocked)
     {
         if (!APIAvailable) return;
-        await Svc.Framework.RunOnFrameworkThread(() => ApplyPresetTuple.Invoke(tuple, asLocked ? GAGSPEAK_KEY : 0)).ConfigureAwait(false);
+        await Svc.Framework.InvokeIPC(() => ApplyPresetTuple.Invoke(tuple, asLocked ? GAGSPEAK_KEY : 0), default).ConfigureAwait(false);
     }
 
     // All of the below should be able to all be called syncronously?..
@@ -322,35 +324,35 @@ public sealed class IpcCallerLoci : IIpcCaller
     public async Task LockStatus(Guid id)
     {
         if (!APIAvailable) return;
-        await Svc.Framework.RunOnFrameworkThread(() => LockStatusById.Invoke(id, GAGSPEAK_KEY)).ConfigureAwait(false);
+        await Svc.Framework.InvokeIPC(() => LockStatusById.Invoke(id, GAGSPEAK_KEY), LociApiEc.UnkError).ConfigureAwait(false);
     }
 
     /// <inheritdoc cref="LociApi.Ipc.LockStatuses"/>
     public async Task LockStatuses(List<Guid> ids)
     {
         if (!APIAvailable) return;
-        await Svc.Framework.RunOnFrameworkThread(() => LockStatusesById.Invoke(ids, GAGSPEAK_KEY, out _)).ConfigureAwait(false);
+        await Svc.Framework.InvokeIPC(() => LockStatusesById.Invoke(ids, GAGSPEAK_KEY, out _), LociApiEc.UnkError).ConfigureAwait(false);
     }
 
     /// <inheritdoc cref="LociApi.Ipc.UnlockStatus"/>
     public async Task UnlockStatus(Guid id)
     {
         if (!APIAvailable) return;
-        await Svc.Framework.RunOnFrameworkThread(() => UnlockStatusById.Invoke(id, GAGSPEAK_KEY)).ConfigureAwait(false);
+        await Svc.Framework.InvokeIPC(() => UnlockStatusById.Invoke(id, GAGSPEAK_KEY), LociApiEc.UnkError).ConfigureAwait(false);
     }
 
     /// <inheritdoc cref="LociApi.Ipc.UnlockStatuses"/>
     public async Task UnlockStatuses(List<Guid> ids)
     {
         if (!APIAvailable) return;
-        await Svc.Framework.RunOnFrameworkThread(() => UnlockStatusesById.Invoke(ids, GAGSPEAK_KEY, out _)).ConfigureAwait(false);
+        await Svc.Framework.InvokeIPC(() => UnlockStatusesById.Invoke(ids, GAGSPEAK_KEY, out _),LociApiEc.UnkError).ConfigureAwait(false);
     }
 
     /// <inheritdoc cref="LociApi.Ipc.UnlockAll"/>
     public async Task ClearAllLocks()
     {
         if (!APIAvailable) return;
-        await Svc.Framework.RunOnFrameworkThread(() => ClearLocks.Invoke(GAGSPEAK_KEY)).ConfigureAwait(false);
+        await Svc.Framework.InvokeIPC(() => ClearLocks.Invoke(GAGSPEAK_KEY), 0).ConfigureAwait(false);
     }
 
 

--- a/ProjectGagSpeak/Interop/IpcHelpers/IPCExtensions.cs
+++ b/ProjectGagSpeak/Interop/IpcHelpers/IPCExtensions.cs
@@ -1,0 +1,26 @@
+using Dalamud.Plugin.Ipc.Exceptions;
+using Dalamud.Plugin.Services;
+
+namespace GagSpeak.Interop.Helpers;
+
+public static class IPCExtensions
+{
+    extension(IFramework fw)
+    {
+        /// <summary>
+        ///  Safely invoke IPC calls on the framework tick, ensuring that asynchronous calls do not have a chance to crash the client because the state changed since we last checked.
+        /// </summary>
+        public async Task<T> InvokeIPC<T>(Func<T> func, T returnOnFail)
+        {
+            try
+            {
+                return await fw.RunOnFrameworkThread(func).ConfigureAwait(false);
+            }
+            catch (IpcNotReadyError ex)
+            {
+                Svc.Logger.Warning("Called IPC when it was shut down/not available.\n" + ex);
+                return returnOnFail;
+            }
+        }
+    }
+}


### PR DESCRIPTION
adds an extension method that ensures thread-safe ipc calls.

this feels like i'm just painting over a deeper problem with collections, or the loci api (much more likely the latter.)

this only manifests if you shutdown gagspeak and loci at the same time with a collection. GS still gets the shutdown message, and properly marks ApiAvailable false, but the removestauts method is still trying to be called, and this will just crash the client...

I wrapped it in a safe extension that catches this behaviour on all loci ipc calls, returning a provided default value if they fail (the exact same value that would have been returned if the method returned early at ApiAvailable)